### PR TITLE
Prefer PopupBridge if it exists in FrameService

### DIFF
--- a/src/lib/frame-service/external/frame-service.js
+++ b/src/lib/frame-service/external/frame-service.js
@@ -213,10 +213,10 @@ FrameService.prototype._getFrameForEnvironment = function (options) {
 
   var initOptions = assign({}, this._options, options);
 
-  if (usePopup) {
-    return new Popup(initOptions);
-  } else if (popupBridgeExists) {
+  if (popupBridgeExists) {
     return new PopupBridge(initOptions);
+  } else if (usePopup) {
+    return new Popup(initOptions);
   }
 
   return new Modal(initOptions);


### PR DESCRIPTION


| [Jira ticket]() |
|---|

### Summary

I'm trying to utilize `braintree-web` in an Electron application, but prefer to throw people over to a browser for the payment itself. I noticed PopupBridge is used for mobile applications, and didn't see any reason I couldn't emulate the functionality in a desktop app. It works with the exception of this specific `_getFrameForEnvironment` private method, which thinks Electron should still open popups rather than use the bridge I've created for it. Simply changing the logic to prefer PopupBridge seems to make it work as intended.
