### PR TITLE
update Google Pay API JavaScript URL and object reference URL

### DIFF
--- a/src/google-payment/google-payment.js
+++ b/src/google-payment/google-payment.js
@@ -45,9 +45,9 @@ function GooglePayment(options) {
 /**
  * Create a configuration object for use in the `loadPaymentData` method.
  * @public
- * @param {object} overrides The supplied parameters for creating the Payment Data Request object. Only required parameters are the `merchantId` provided by Google and a `transactionInfo` object, but any of the parameters in the Payment Data Request can be overwritten. See https://developers.google.com/payments/web/object-reference#PaymentDataRequest
+ * @param {object} overrides The supplied parameters for creating the PaymentDataRequest object. Only required parameters are the `merchantId` provided by Google and a `transactionInfo` object, but any of the parameters in the PaymentDataRequest can be overwritten. See https://developers.google.com/pay/api/web/reference/object#PaymentDataRequest
  * @param {string} merchantId The merchant id provided by registering with Google.
- * @param {object} transactionInfo See https://developers.google.com/payments/web/object-reference#TransactionInfo for more information.
+ * @param {object} transactionInfo See https://developers.google.com/pay/api/web/reference/object#TransactionInfo for more information.
  * @example
  * var configuration = googlePaymentInstance.createPaymentDataRequest({
  *   merchantId: 'my-merchant-id-from-google',
@@ -65,7 +65,7 @@ function GooglePayment(options) {
  *   // handle response with googlePaymentInstance.parseResponse
  *   // (see below)
  * });
- * @returns {object} Returns a configuration object for Google Payment Request.
+ * @returns {object} Returns a configuration object for Google PaymentDataRequest.
  */
 GooglePayment.prototype.createPaymentDataRequest = function (overrides) {
   analytics.sendEvent(this._client, 'google-payment.createPaymentDataRequest');

--- a/src/google-payment/index.js
+++ b/src/google-payment/index.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @module braintree-web/google-payment
- * @description A component to integrate with Google Pay. The majority of the integration uses [Google's pay.js JavaScript file](https://payments.developers.google.com/js/apis/pay.js). The Braintree component generates the configuration object necessary for Google Pay to initiate the Payment Request and parse the returned data to retrieve the payment method nonce which is used to process the transaction on the server.
+ * @description A component to integrate with Google Pay. The majority of the integration uses [Google's pay.js JavaScript file](https://pay.google.com/gp/p/js/pay.js). The Braintree component generates the configuration object necessary for Google Pay to initiate the Payment Request and parse the returned data to retrieve the payment method nonce which is used to process the transaction on the server.
  */
 
 var basicComponentVerification = require('../lib/basic-component-verification');
@@ -18,8 +18,8 @@ var VERSION = process.env.npm_package_version;
  * @param {Client} options.client A {@link Client} instance.
  * @param {callback} [callback] The second argument, `data`, is the {@link GooglePayment} instance. If no callback is provided, `create` returns a promise that resolves with the {@link GooglePayment} instance.
  * @example <caption>Simple Example</caption>
- * // include https://payments.developers.google.com/js/apis/pay.js in a script tag
- * // on your page to load the `google.api.PaymentsClient` global object.
+ * // include https://pay.google.com/gp/p/js/pay.js in a script tag
+ * // on your page to load the `google.payments.api.PaymentsClient` global object.
  *
  * var paymentButton = document.querySelector('#google-pay-button');
  * var paymentsClient = new google.payments.api.PaymentsClient({


### PR DESCRIPTION
Documentation changes only.

Google API changed its JavaScript URL in May 2018.

Update link to Google Pay API Web object reference documentation.

Google Pay API reference documentation documents the structure of the object passed to loadPaymentData() as "PaymentDataRequest" not "Payment Data Request"; change documentation mentions to match.