### PR TITLE
Don't trim URL if no hash fragments are set

### DIFF
--- a/src/venmo/venmo.js
+++ b/src/venmo/venmo.js
@@ -244,7 +244,7 @@ function getFragmentParameters() {
 }
 
 function clearFragmentParameters() {
-  if (typeof global.history.replaceState === 'function' && global.location.href.indexOf('#') !== -1) {
+  if (typeof global.history.replaceState === 'function' && global.location.hash) {
     history.pushState({}, '', global.location.href.slice(0, global.location.href.indexOf('#')));
   }
 }

--- a/src/venmo/venmo.js
+++ b/src/venmo/venmo.js
@@ -244,7 +244,7 @@ function getFragmentParameters() {
 }
 
 function clearFragmentParameters() {
-  if (typeof global.history.replaceState === 'function') {
+  if (typeof global.history.replaceState === 'function' && global.location.href.indexOf('#') !== -1) {
     history.pushState({}, '', global.location.href.slice(0, global.location.href.indexOf('#')));
   }
 }

--- a/test/venmo/unit/venmo.js
+++ b/test/venmo/unit/venmo.js
@@ -437,6 +437,18 @@ describe('Venmo', function () {
 
         return promise;
       });
+
+      it('preserves URL if fragments are never set', function () {
+        var originalURL = window.location.href;
+
+        var promise = this.venmo.tokenize().then(rejectIfResolves).catch(function () {
+          expect(window.location.href).to.equal(originalURL);
+        });
+
+        triggerWindowVisibilityChangeListener();
+
+        return promise;
+      });
     });
 
     context('with callbacks', function () {
@@ -627,6 +639,14 @@ describe('Venmo', function () {
 
         history.replaceState({}, '', window.location.href + '#venmoCancel=1');
         triggerWindowVisibilityChangeListener();
+      });
+
+      it('preserves URL if fragments are never set', function () {
+        var originalURL = window.location.href;
+
+        return this.venmo.tokenize(function () {
+          expect(window.location.href).to.equal(originalURL);
+        });
       });
     });
 


### PR DESCRIPTION
### Summary

#### The Problem
When `tokenize()` is called on a Venmo client to initiate the Venmo payment flow but the user exits the app immediately without any interaction, no response data gets returned to the browser, so no URL fragments get set. 

The visibility change listener then executes `_processResults()` as normal, without knowing nothing was passed back from the app. This in turn executes this function:
```javascript
if (typeof global.history.replaceState === 'function') {
  history.pushState({}, '', global.location.href.slice(0, global.location.href.indexOf('#')));
}
```

Because no fragments were set, the character `"#"` is not present in the URL, so `indexOf("#")` will return `-1`. Thus the above code resolves to:
```javascript
if (typeof global.history.replaceState === 'function') {
  history.pushState({}, '', global.location.href.slice(0, -1));
}
```

Calling `slice(0, -1)` trims the last character from the URL, and adds an invalid entry to the browser history.

This issue was experienced on on iPhone XS running iOS 12.0.1 with Venmo v7.24.0.

#### The Fix
Pretty simple - don't attempt to remove the fragments from the URL if they aren't present:
```javascript
if (typeof global.history.replaceState === 'function' && global.location.href.indexOf('#') !== -1) {
  history.pushState({}, '', global.location.href.slice(0, global.location.href.indexOf('#')));
}
```

### Checklist

- [ ] Added a changelog entry
