### PR TITLE
added some attributes to iframes to make them more accessible[patch]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 CHANGELOG
 =========
-## 3.45.1
+## unreleased
 * Add `title` and `aria-hidden` attributes to iframes created within `frameService` for accessibility
 
 ## 3.45.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG
 =========
+## 3.45.1
+* Add `title` and `aria-hidden` attributes to iframes created within `frameService` for accessibility
+
 ## 3.45.0
 * Update @braintree/wrap-promise to v2.0.0 - errors thrown inside developer supplied callback functions will log to the console
 * Update restricted-input to v2.0.0

--- a/src/lib/frame-service/external/frame-service.js
+++ b/src/lib/frame-service/external/frame-service.js
@@ -73,7 +73,9 @@ FrameService.prototype._writeDispatchFrame = function () {
   var frameSrc = this._options.dispatchFrameUrl;
 
   this._dispatchFrame = iFramer({
+    'aria-hidden': true,
     name: frameName,
+    title: frameName,
     src: frameSrc,
     'class': constants.DISPATCH_FRAME_CLASS,
     height: 0,


### PR DESCRIPTION
| [Jira ticket]() |
|---|

### Summary
this is in response to: https://github.com/braintree/braintree-web/issues/434

the `aria-hidden` attribute is correct if the `frameService` is only ever used to create iframes without interactive content. i can remove it if that isn't the case.

### Checklist

- [x] Added a changelog entry
