### PR TITLE
Add iframe title, Add image alt

### DIFF
--- a/src/data-collector/kount.js
+++ b/src/data-collector/kount.js
@@ -92,11 +92,12 @@ Kount.prototype._setupIFrame = function () {
   iframe.style.position = 'fixed';
   iframe.style.left = '-999999px';
   iframe.style.top = '-999999px';
+  iframe.title = IFRAME_ID_PREFIX + this._deviceSessionId;
 
   document.body.appendChild(iframe);
   setTimeout(function () {
     iframe.src = self._currentEnvironment.url + '/logo.htm' + params;
-    iframe.innerHTML = '<img src="' + self._currentEnvironment.url + '/logo.gif' + params + '" />';
+    iframe.innerHTML = '<img src="' + self._currentEnvironment.url + '/logo.gif' + params + '" alt="" />';
   }, 10);
 
   return iframe;

--- a/src/data-collector/kount.js
+++ b/src/data-collector/kount.js
@@ -92,7 +92,8 @@ Kount.prototype._setupIFrame = function () {
   iframe.style.position = 'fixed';
   iframe.style.left = '-999999px';
   iframe.style.top = '-999999px';
-  iframe.title = IFRAME_ID_PREFIX + this._deviceSessionId;
+  iframe.title = 'Braintree-Kount-iframe';
+  iframe.setAttribute('aria-hidden', 'true');
 
   document.body.appendChild(iframe);
   setTimeout(function () {


### PR DESCRIPTION
### Summary
The Data Collector Iframe is not passing the accessibility tests because:
- the iframe has no `title`
- the img element has no `alt`

I'm checking with [Arc Toolkit](https://chrome.google.com/webstore/detail/arc-toolkit/chdkkkccnlfncngelccgbgfmjebmkmce?hl=en) on Google Chrome.

This PR will solve problems like:

![Screenshot 2020-01-16 at 16](https://user-images.githubusercontent.com/5058640/72536022-cecd9800-3879-11ea-9eda-d310ad11161e.jpg)
<img width="555" alt="Screenshot 2020-01-16 at 16 01 13" src="https://user-images.githubusercontent.com/5058640/72536064-db51f080-3879-11ea-893e-7e91ae1c6a40.png">


### Checklist

- [ ] Added a changelog entry
