### PR TITLE
Allow setting the css background-color style for hosted fields

### DIFF
--- a/src/hosted-fields/shared/constants.js
+++ b/src/hosted-fields/shared/constants.js
@@ -55,6 +55,7 @@ var constants = {
     '-webkit-tap-highlight-color',
     '-webkit-transition',
     'appearance',
+    'background-color',
     'color',
     'direction',
     'font',


### PR DESCRIPTION
### Summary

Please support the 'background-color' css property for hosted fields.  The documentation at https://developers.braintreepayments.com/guides/hosted-fields/styling/javascript/v3 indicates that the background should be set within the website, implying that the hosted field is transparent.  However, the `hc_extension_bkgnd` div forces the background to be white.  While it is possible that there may be a security risk with supporting the entire `background` css property (allowing tiled backgrounds and such), the `background-color` property only supports colors.  All of the other `background...` properties of css relate to tiled backgrounds, so there is no point in supporting them if tiled backgrounds are understandably unsupported.

Here is the snippet from the Braintree website for reference:

> Hosted Fields defers as much of the styling of field components to you as possible. The layout, width, height, and outer styling (`border`, `box-shadow`, `background`, etc.) are left completely in your control. 

This feature is necessary to properly support websites that support dark mode, or any other time when the background color is not white.  Personally, I'm trying to set `input[disabled]` to have a background color of `#ddd`, to make it match the rest of my website when the control is disabled.

An alternative option would be to change the background color setting of `rgb(255,255,255)` to `transparent` on the `hc_extension_bkgnd` div, but this could break existing applications.

Please consider this request.

### Checklist

- [ ] Added a changelog entry
