### PR TITLE
Add the inputmode attribute

### DIFF
--- a/src/hosted-fields/internal/components/base-input.js
+++ b/src/hosted-fields/internal/components/base-input.js
@@ -16,6 +16,7 @@ function constructAttributes(options) {
   var name = options.name;
   var attributes = {
     autocomplete: constants.autocompleteMappings[name],
+    inputmode: constants.inputmodeMappings[name],
     type: options.type,
     autocorrect: 'off',
     autocapitalize: 'none',

--- a/src/hosted-fields/internal/index.js
+++ b/src/hosted-fields/internal/index.js
@@ -92,7 +92,6 @@ function makeMockInput(name) {
   input.type = 'text';
   input.name = name;
   input.setAttribute('autocomplete', constants.autocompleteMappings[name]);
-  input.setAttribute('inputmode', constants.inputmodeMappings[name]);
 
   // Normally we'd mark these hidden inputs
   // with tabindex=-1 to prevent the customer

--- a/src/hosted-fields/internal/index.js
+++ b/src/hosted-fields/internal/index.js
@@ -92,6 +92,7 @@ function makeMockInput(name) {
   input.type = 'text';
   input.name = name;
   input.setAttribute('autocomplete', constants.autocompleteMappings[name]);
+  input.setAttribute('inputmode', constants.inputmodeMappings[name]);
 
   // Normally we'd mark these hidden inputs
   // with tabindex=-1 to prevent the customer

--- a/src/hosted-fields/shared/constants.js
+++ b/src/hosted-fields/shared/constants.js
@@ -132,6 +132,15 @@ var constants = {
     'expiration-year': 'cc-exp-year',
     cvv: 'cc-csc',
     'postal-code': 'billing postal-code'
+  },
+  inputmodeMappings: {
+    'cardholder-name': 'text',
+    'credit-card-number': 'numeric',
+    expiration: 'numeric',
+    'expiration-month': 'numeric',
+    'expiration-year': 'numeric',
+    cvv: 'numeric',
+    'postal-code': 'text'
   }
 };
 


### PR DESCRIPTION
### Summary
Adds the [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) attribute to the form fields. Fixes #541.

### Checklist

- [ ] Added a changelog entry
