### PR TITLE
Make `npm repo braintree-web` open the Github repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/braintree/braintree-web.git"
+    "url": "https://github.com/braintree/braintree-web"
   },
   "scripts": {
     "jsdoc": "./scripts/npm-to-gulp jsdoc",


### PR DESCRIPTION
This simple change makes `npm repo braintree-web` open the Github repository for the package in the users default browser. This should not have any side effects.

### Summary


### Checklist

- [ ] Added a changelog entry
