### PR TITLE
DTBTPWPP-1664 - Add options.displayName to Local Payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+  - Local Payments
+      - Add `options.displayName` to `startPayment`
+
 # 3.82.0
 
   - Update @braintree/browser-detection to v1.12.1

--- a/src/local-payment/external/local-payment.js
+++ b/src/local-payment/external/local-payment.js
@@ -72,6 +72,7 @@ LocalPayment.prototype._initialize = function () {
  * @param {number} [options.windowOptions.height=720] The height in pixels of the window opened when starting the payment.
  * @param {string} options.amount The amount to authorize for the transaction.
  * @param {string} options.currencyCode The currency to process the payment.
+ * @param {string} options.displayName The merchant name displayed inside of the window that is opened when starting the payment.
  * @param {string} options.paymentType The type of local payment.
  * @param {string} options.paymentTypeCountryCode The country code of the local payment. This value must be one of the supported country codes for a given local payment type listed {@link https://developer.paypal.com/braintree/docs/guides/local-payment-methods/client-side-custom/javascript/v3#render-local-payment-method-buttons|here}. For local payments supported in multiple countries, this value may determine which banks are presented to the customer.
  * @param {string} options.email Payer email of the customer.
@@ -145,6 +146,7 @@ LocalPayment.prototype.startPayment = function (options) {
       c: 1 // indicating we went through the cancel flow
     }),
     experienceProfile: {
+      brandName: options.displayName,
       noShipping: !options.shippingAddressRequired
     },
     fundingSource: options.paymentType,

--- a/test/local-payment/unit/external/local-payment.js
+++ b/test/local-payment/unit/external/local-payment.js
@@ -175,6 +175,7 @@ describe('LocalPayment', () => {
         email: 'email@example.com',
         phone: '1234',
         bic: 'ABGANL6A',
+        displayName: 'My Brand!',
         address: {
           streetAddress: '123 Address',
           extendedAddress: 'Unit 1',
@@ -255,6 +256,7 @@ describe('LocalPayment', () => {
             amount: '10.00',
             intent: 'sale',
             experienceProfile: {
+              brandName: 'My Brand!',
               noShipping: false
             },
             currencyIsoCode: 'USD',
@@ -295,6 +297,7 @@ describe('LocalPayment', () => {
             amount: '10.00',
             intent: 'sale',
             experienceProfile: {
+              brandName: 'My Brand!',
               noShipping: false
             },
             currencyIsoCode: 'USD',


### PR DESCRIPTION
### Summary

Adds `options.displayName` to Local Payments `startPayment` function.

### Checklist

- [x] Added a changelog entry
