### PR TITLE
DTBTPWPP - Add user authentication email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+- PayPal Checkout
+  - Add `userAuthenticationEmail` to `createPayment`
+
 ## 3.107.1 
 - Hosted Fields
   - Fix passing through a sessionId value

--- a/src/paypal-checkout/paypal-checkout.js
+++ b/src/paypal-checkout/paypal-checkout.js
@@ -434,6 +434,7 @@ PayPalCheckout.prototype._setupFrameService = function (client) {
  *
  * @param {string} [options.planType] Determines the charge pattern for the Recurring Billing Agreement. Can be 'RECURRING', 'SUBSCRIPTION', 'UNSCHEDULED', or 'INSTALLMENTS'.
  * @param {planMetadata} [options.planMetadata] When plan type is defined, allows for {@link PayPalCheckout~planMetadata|plan metadata} to be set for the Billing Agreement.
+ * @param {string} [options.userAuthenticationEmail] User email to initiate a quicker authentication flow in cases where the user has a PayPal Account with the same email.
  *
  * @param {callback} [callback] The second argument is a PayPal `paymentId` or `billingToken` string, depending on whether `options.flow` is `checkout` or `vault`. This is also what is resolved by the promise if no callback is provided.
  * @example
@@ -1435,6 +1436,7 @@ PayPalCheckout.prototype._formatPaymentResourceData = function (
       landingPageType: options.landingPageType,
     },
     shippingOptions: options.shippingOptions,
+    payerEmail: options.userAuthenticationEmail,
   };
 
   if (options.flow === "checkout") {

--- a/test/paypal-checkout/unit/paypal-checkout.js
+++ b/test/paypal-checkout/unit/paypal-checkout.js
@@ -434,6 +434,20 @@ describe("PayPalCheckout", () => {
             });
           }));
 
+      it("contains the payer email when specified", () => {
+        testContext.options.userAuthenticationEmail = "the@email.com";
+
+        return testContext.paypalCheckout
+          .createPayment(testContext.options)
+          .then(() => {
+            expect(testContext.client.request.mock.calls[0][0]).toMatchObject({
+              data: {
+                payerEmail: "the@email.com",
+              },
+            });
+          });
+      });
+
       describe("when using checkout flow", () => {
         beforeEach(() => {
           testContext.options.flow = "checkout";


### PR DESCRIPTION
### Summary

Add support for userAuthenticationEmail, which sends `payerEmail` to the create_payment_resource and setup_billing_agreement endpoints for Pay with PayPal.

The iOS and Android SDKs already support passing the payer_email field, and this adds support to the JS SDK.

### Checklist

- [x] Added a changelog entry
