### PR TITLE
Add early exit to camel-to-snake for null values

### DIFF
--- a/src/lib/camel-case-to-snake-case.js
+++ b/src/lib/camel-case-to-snake-case.js
@@ -11,6 +11,10 @@ function transformKey(key) {
 function camelCaseToSnakeCase(input) {
   var converted;
 
+  if (null === input) {
+      return null;
+  }
+
   if (Array.isArray(input)) {
     converted = [];
 

--- a/test/lib/unit/camel-case-to-snake-case.js
+++ b/test/lib/unit/camel-case-to-snake-case.js
@@ -106,4 +106,45 @@ describe("camelCaseToSnakeCase", () => {
 
     expect(camelCaseToSnakeCase(arrayOfValues)).toEqual(expectedArrayOfValues);
   });
+
+  it("returns of mixed types", () => {
+    const values = {
+      "snake_to_snake": false,
+      "camelToSnake": true,
+      "nullableField": null,
+      "decimal": 1.5,
+      "stringValue": "stringValue",
+      "nestedObject": {
+        "stringValue": "stringValue",
+      },
+      "nestedArray": [
+        "camelValueLiteral",
+        {
+          "nestedObject": {
+            "stringValue": "stringValue",
+          },
+        },
+      ],
+    };
+    const expectedValues = {
+      "snake_to_snake": false,
+      "camel_to_snake": true,
+      "nullable_field": null,
+      "decimal": 1.5,
+      "string_value": "stringValue",
+      "nested_object": {
+        "string_value": "stringValue",
+      },
+      "nested_array": [
+        "camelValueLiteral",
+        {
+          "nested_object": {
+            "string_value": "stringValue",
+          },
+        },
+      ],
+    };
+
+    expect(camelCaseToSnakeCase(values)).toEqual(expectedValues);
+  });
 });


### PR DESCRIPTION
### Summary

Add early exit to camel-to-snake for null values to avoid error about converting null to an object.

### Checklist

- [ ] Added a changelog entry
