### PR TITLE
Support dark mode for hosted fields

### DIFF
--- a/src/hosted-fields/internal/hosted-fields-frame.html
+++ b/src/hosted-fields/internal/hosted-fields-frame.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-
+    <meta name="color-scheme" content="light dark">
     <style>
       * {
         margin: 0;


### PR DESCRIPTION
### Summary

- Support dark mode in Hosted Fields by adding meta color-scheme tag to iframe
  - Without this change it is impossible to render hosted inputs with a dark background for dark themed sites

Support 

### Checklist

- [ ] Added a changelog entry
