### PR TITLE
Add agent skills discovery for AI-assisted SDK integration

### DIFF
--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "braintree-3d-secure",
+      "type": "skill-md",
+      "description": "3D Secure v2 authentication with Cardinal Commerce Songbird - verifyCard flow, challenge handling, SCA exemptions",
+      "url": "skills/braintree-3d-secure.md",
+      "digest": "sha256:5b807410a5694e234e73185a2cac1fb1d45c37eb24b878628f2565be376fb1ea"
+    },
+    {
+      "name": "braintree-advanced-patterns",
+      "type": "skill-md",
+      "description": "SDK internals and shared patterns - dual API, events, deferred client, Frame Service, CSP, analytics, teardown",
+      "url": "skills/braintree-advanced-patterns.md",
+      "digest": "sha256:8ab4d44f6cef1dd2421e636800cfb6766e46b392d8fc9e6fee994a85b9b981cd"
+    },
+    {
+      "name": "braintree-alternative-payments",
+      "type": "skill-md",
+      "description": "Local payment methods (iDEAL, Sofort, Bancontact, BLIK), SEPA Direct Debit, and US Bank Account (ACH) integration",
+      "url": "skills/braintree-alternative-payments.md",
+      "digest": "sha256:67867e5232e430227d7056ab3613ae4ba798db3b17ec87de4f90b6793785bb89"
+    },
+    {
+      "name": "braintree-apple-pay",
+      "type": "skill-md",
+      "description": "Apple Pay web integration via ApplePaySession - payment requests, merchant validation, and tokenization",
+      "url": "skills/braintree-apple-pay.md",
+      "digest": "sha256:6d4ee46921c133af0515995b382e0671aab8191a5ba1b1a76962884c4765818e"
+    },
+    {
+      "name": "braintree-card-payment-full",
+      "type": "skill-md",
+      "description": "End-to-end card payment orchestration combining Hosted Fields, 3D Secure, and Data Collector",
+      "url": "skills/braintree-card-payment-full.md",
+      "digest": "sha256:4eb571d4a9d87f15c918f6098e5d8f4473f42e7a2954d942e6c09f43e6e918ee"
+    },
+    {
+      "name": "braintree-card-payments",
+      "type": "skill-md",
+      "description": "Hosted Fields PCI-compliant card collection via iframes - field configuration, styling, events, and tokenization",
+      "url": "skills/braintree-card-payments.md",
+      "digest": "sha256:a662207e5040e64e455f075a53d066a4fcac95be0285fe4a13a3c7ee3b3b5ff8"
+    },
+    {
+      "name": "braintree-error-resolution",
+      "type": "skill-md",
+      "description": "Complete error code reference and resolution guide for all Braintree Web SDK components - maps every error to its fix",
+      "url": "skills/braintree-error-resolution.md",
+      "digest": "sha256:d697316db3fc81fd5beef25133c3a6b07c091d641457bfe9f2cc3c48c0982c91"
+    },
+    {
+      "name": "braintree-google-pay",
+      "type": "skill-md",
+      "description": "Google Pay v2 integration via Google Pay API - PaymentsClient, payment data request, and response parsing",
+      "url": "skills/braintree-google-pay.md",
+      "digest": "sha256:8c89174cd639e7867c6c4dd50d51eec5fd11454cd2ab600b58fd84286527f792"
+    },
+    {
+      "name": "braintree-migration-guide",
+      "type": "skill-md",
+      "description": "Version migration paths, deprecated component replacements, and breaking changes for Braintree Web SDK",
+      "url": "skills/braintree-migration-guide.md",
+      "digest": "sha256:5c2a1b95a9a8c23a8804aa27dd0e323ba4e24ba22d09174c3ac23f5e18224064"
+    },
+    {
+      "name": "braintree-paypal",
+      "type": "skill-md",
+      "description": "PayPal integration via paypal-checkout and paypal-checkout-v6 - checkout, vault, and VIC flows",
+      "url": "skills/braintree-paypal.md",
+      "digest": "sha256:a4db50a4ccf463153d8166c640cbb63d68945d436b036e6c86952e713e95b90b"
+    },
+    {
+      "name": "braintree-sdk-overview",
+      "type": "skill-md",
+      "description": "Braintree Web SDK v3 architecture, component lifecycle, authorization types, and integration guide",
+      "url": "skills/braintree-sdk-overview.md",
+      "digest": "sha256:e714abd86ce28fc337c239ceb2fb6259ba730837bd30d19cba7118b3ac18bddf"
+    },
+    {
+      "name": "braintree-venmo",
+      "type": "skill-md",
+      "description": "Venmo payments across mobile and desktop - app deep-link, QR code, web login, polling, and browser detection",
+      "url": "skills/braintree-venmo.md",
+      "digest": "sha256:281c113e8d6b5cff528e1b534d4d533ba957471cb710819ecbd2ec3fac82d128"
+    }
+  ]
+}

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -6,84 +6,84 @@
       "type": "skill-md",
       "description": "3D Secure v2 authentication with Cardinal Commerce Songbird - verifyCard flow, challenge handling, SCA exemptions",
       "url": "skills/braintree-3d-secure.md",
-      "digest": "sha256:5b807410a5694e234e73185a2cac1fb1d45c37eb24b878628f2565be376fb1ea"
+      "digest": "sha256:57ff3e563ed459b573f587e5d432de070f6d98bcadc16c8c589a27bef845ca42"
     },
     {
       "name": "braintree-advanced-patterns",
       "type": "skill-md",
       "description": "SDK internals and shared patterns - dual API, events, deferred client, Frame Service, CSP, analytics, teardown",
       "url": "skills/braintree-advanced-patterns.md",
-      "digest": "sha256:8ab4d44f6cef1dd2421e636800cfb6766e46b392d8fc9e6fee994a85b9b981cd"
+      "digest": "sha256:19d162d8a5ee8980b5df09961f660e9b621ae888036662c7e903fcb7e4876627"
     },
     {
       "name": "braintree-alternative-payments",
       "type": "skill-md",
       "description": "Local payment methods (iDEAL, Sofort, Bancontact, BLIK), SEPA Direct Debit, and US Bank Account (ACH) integration",
       "url": "skills/braintree-alternative-payments.md",
-      "digest": "sha256:67867e5232e430227d7056ab3613ae4ba798db3b17ec87de4f90b6793785bb89"
+      "digest": "sha256:fb077137491d966f624710daf7c02d279e6041e3379ef0b0238ecbf8baaa1db0"
     },
     {
       "name": "braintree-apple-pay",
       "type": "skill-md",
       "description": "Apple Pay web integration via ApplePaySession - payment requests, merchant validation, and tokenization",
       "url": "skills/braintree-apple-pay.md",
-      "digest": "sha256:6d4ee46921c133af0515995b382e0671aab8191a5ba1b1a76962884c4765818e"
+      "digest": "sha256:8dd2ac66afda2335b1ff1015c3864722836cac97b6008dc6168a5876bc30838e"
     },
     {
       "name": "braintree-card-payment-full",
       "type": "skill-md",
       "description": "End-to-end card payment orchestration combining Hosted Fields, 3D Secure, and Data Collector",
       "url": "skills/braintree-card-payment-full.md",
-      "digest": "sha256:4eb571d4a9d87f15c918f6098e5d8f4473f42e7a2954d942e6c09f43e6e918ee"
+      "digest": "sha256:e012fde5fc85100501b2f1bff22c3c8c80e2ab3678dfd1822149c863ddec5ba9"
     },
     {
       "name": "braintree-card-payments",
       "type": "skill-md",
       "description": "Hosted Fields PCI-compliant card collection via iframes - field configuration, styling, events, and tokenization",
       "url": "skills/braintree-card-payments.md",
-      "digest": "sha256:a662207e5040e64e455f075a53d066a4fcac95be0285fe4a13a3c7ee3b3b5ff8"
+      "digest": "sha256:3a8e1b438158be2409c34b86c17f79b4c2ff816e6011a58522140e580e2f1192"
     },
     {
       "name": "braintree-error-resolution",
       "type": "skill-md",
       "description": "Complete error code reference and resolution guide for all Braintree Web SDK components - maps every error to its fix",
       "url": "skills/braintree-error-resolution.md",
-      "digest": "sha256:d697316db3fc81fd5beef25133c3a6b07c091d641457bfe9f2cc3c48c0982c91"
+      "digest": "sha256:8c1547ace052af9b96e53acc370e613d825b22e77726b1933b0261524ba783bc"
     },
     {
       "name": "braintree-google-pay",
       "type": "skill-md",
       "description": "Google Pay v2 integration via Google Pay API - PaymentsClient, payment data request, and response parsing",
       "url": "skills/braintree-google-pay.md",
-      "digest": "sha256:8c89174cd639e7867c6c4dd50d51eec5fd11454cd2ab600b58fd84286527f792"
+      "digest": "sha256:31f741856bbb7041c57fc56d939801ba89cf3bb4efac6c009c87e10b87d5bdec"
     },
     {
       "name": "braintree-migration-guide",
       "type": "skill-md",
       "description": "Version migration paths, deprecated component replacements, and breaking changes for Braintree Web SDK",
       "url": "skills/braintree-migration-guide.md",
-      "digest": "sha256:5c2a1b95a9a8c23a8804aa27dd0e323ba4e24ba22d09174c3ac23f5e18224064"
+      "digest": "sha256:e5ae368625e5072f4a51086d56775086f757db455a289b6608e6892fee7099c7"
     },
     {
       "name": "braintree-paypal",
       "type": "skill-md",
       "description": "PayPal integration via paypal-checkout and paypal-checkout-v6 - checkout, vault, and VIC flows",
       "url": "skills/braintree-paypal.md",
-      "digest": "sha256:a4db50a4ccf463153d8166c640cbb63d68945d436b036e6c86952e713e95b90b"
+      "digest": "sha256:fca9627cf5b97c621312d44d4d9805d34b24520b9670a3e0dd3df414a84a0e56"
     },
     {
       "name": "braintree-sdk-overview",
       "type": "skill-md",
       "description": "Braintree Web SDK v3 architecture, component lifecycle, authorization types, and integration guide",
       "url": "skills/braintree-sdk-overview.md",
-      "digest": "sha256:e714abd86ce28fc337c239ceb2fb6259ba730837bd30d19cba7118b3ac18bddf"
+      "digest": "sha256:2c7f63714eeab98652124d41c2b00a1b77752d31b22fd16e1307dffe8b64e78c"
     },
     {
       "name": "braintree-venmo",
       "type": "skill-md",
       "description": "Venmo payments across mobile and desktop - app deep-link, QR code, web login, polling, and browser detection",
       "url": "skills/braintree-venmo.md",
-      "digest": "sha256:281c113e8d6b5cff528e1b534d4d533ba957471cb710819ecbd2ec3fac82d128"
+      "digest": "sha256:fbe0d69722e16c9af5d67f6e382862c21e249d181c6cc95ca71b8cb5d3487bba"
     }
   ]
 }

--- a/.well-known/agent-skills/skills/braintree-3d-secure.md
+++ b/.well-known/agent-skills/skills/braintree-3d-secure.md
@@ -15,17 +15,21 @@ description: 3D Secure v2 authentication with Cardinal Commerce Songbird - verif
 ## Setup
 
 ```javascript
-braintree.threeDSecure.create({
-  client: clientInstance,
-  version: '2',                    // Required: '2', '2-bootstrap3-modal', or '2-inline-iframe'
-  cardinalSDKConfig: {             // Optional
-    logging: { level: 'verbose' }, // 'on', 'verbose', 'off'
-    timeout: 10000,                // Cardinal API timeout (ms)
-    maxRequestRetries: 3
+braintree.threeDSecure.create(
+  {
+    client: clientInstance,
+    version: "2", // Required: '2', '2-bootstrap3-modal', or '2-inline-iframe'
+    cardinalSDKConfig: {
+      // Optional
+      logging: { level: "verbose" }, // 'on', 'verbose', 'off'
+      timeout: 10000, // Cardinal API timeout (ms)
+      maxRequestRetries: 3,
+    },
+  },
+  function (err, threeDSecureInstance) {
+    // Ready
   }
-}, function (err, threeDSecureInstance) {
-  // Ready
-});
+);
 ```
 
 ## Authentication Flow
@@ -39,7 +43,7 @@ Tokenize card (Hosted Fields) -> verifyCard() -> lookup-complete event -> challe
 ### Step 1: Register Lookup Handler
 
 ```javascript
-threeDSecureInstance.on('lookup-complete', function (data, next) {
+threeDSecureInstance.on("lookup-complete", function (data, next) {
   // data.requiresUserAuthentication -- true if challenge needed
   // data.threeDSecureInfo.liabilityShifted -- true if already shifted
   // data.threeDSecureInfo.liabilityShiftPossible -- true if shift achievable
@@ -52,59 +56,68 @@ threeDSecureInstance.on('lookup-complete', function (data, next) {
 ### Step 2: Verify Card
 
 ```javascript
-threeDSecureInstance.verifyCard({
-  nonce: payload.nonce,        // From hostedFields.tokenize()
-  bin: payload.details.bin,    // Required: card BIN
-  amount: '100.00',           // Required: transaction amount
+threeDSecureInstance.verifyCard(
+  {
+    nonce: payload.nonce, // From hostedFields.tokenize()
+    bin: payload.details.bin, // Required: card BIN
+    amount: "100.00", // Required: transaction amount
 
-  // Optional but recommended for better approval rates:
-  email: 'customer@example.com',
-  mobilePhoneNumber: '5551234567',
-  billingAddress: {
-    givenName: 'John',
-    surname: 'Doe',
-    streetAddress: '123 Main St',
-    locality: 'Chicago',
-    region: 'IL',
-    postalCode: '60606',
-    countryCodeAlpha2: 'US'
+    // Optional but recommended for better approval rates:
+    email: "customer@example.com",
+    mobilePhoneNumber: "5551234567",
+    billingAddress: {
+      givenName: "John",
+      surname: "Doe",
+      streetAddress: "123 Main St",
+      locality: "Chicago",
+      region: "IL",
+      postalCode: "60606",
+      countryCodeAlpha2: "US",
+    },
+  },
+  function (err, verifyPayload) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+
+    // verifyPayload.nonce -- NEW nonce to send to server
+    // verifyPayload.threeDSecureInfo.liabilityShifted -- boolean
+    // verifyPayload.threeDSecureInfo.liabilityShiftPossible -- boolean
+    submitToServer(verifyPayload.nonce);
   }
-}, function (err, verifyPayload) {
-  if (err) { console.error(err); return; }
-
-  // verifyPayload.nonce -- NEW nonce to send to server
-  // verifyPayload.threeDSecureInfo.liabilityShifted -- boolean
-  // verifyPayload.threeDSecureInfo.liabilityShiftPossible -- boolean
-  submitToServer(verifyPayload.nonce);
-});
+);
 ```
 
 ## Outcome Scenarios
 
-| Scenario | requiresUserAuthentication | liabilityShifted | liabilityShiftPossible | Action |
-|----------|---------------------------|------------------|------------------------|--------|
-| Frictionless success | false | true | true | Use nonce, liability shifted |
-| Challenge required | true | false | true | Call `next()`, user completes challenge |
-| Not enrolled | false | false | false | Use nonce, seller assumes liability |
-| Auth failed | - | false | true | Decide whether to proceed without shift |
+| Scenario             | requiresUserAuthentication | liabilityShifted | liabilityShiftPossible | Action                                  |
+| -------------------- | -------------------------- | ---------------- | ---------------------- | --------------------------------------- |
+| Frictionless success | false                      | true             | true                   | Use nonce, liability shifted            |
+| Challenge required   | true                       | false            | true                   | Call `next()`, user completes challenge |
+| Not enrolled         | false                      | false            | false                  | Use nonce, seller assumes liability     |
+| Auth failed          | -                          | false            | true                   | Decide whether to proceed without shift |
 
 ## Framework Options
 
-| Version String | UI | Requirements |
-|---------------|-----|-------------|
-| `'2'` | Cardinal managed modal | None (default) |
-| `'2-bootstrap3-modal'` | Bootstrap 3 modal | Bootstrap 3 CSS/JS + jQuery loaded |
-| `'2-inline-iframe'` | Merchant-placed iframe | Handle `authentication-iframe-available` event |
+| Version String         | UI                     | Requirements                                   |
+| ---------------------- | ---------------------- | ---------------------------------------------- |
+| `'2'`                  | Cardinal managed modal | None (default)                                 |
+| `'2-bootstrap3-modal'` | Bootstrap 3 modal      | Bootstrap 3 CSS/JS + jQuery loaded             |
+| `'2-inline-iframe'`    | Merchant-placed iframe | Handle `authentication-iframe-available` event |
 
 ### Inline Iframe
 
 ```javascript
-threeDSecureInstance.on('authentication-iframe-available', function (event, next) {
-  document.getElementById('3ds-container').appendChild(event.element);
-  next(); // Signal iframe is on page
-});
+threeDSecureInstance.on(
+  "authentication-iframe-available",
+  function (event, next) {
+    document.getElementById("3ds-container").appendChild(event.element);
+    next(); // Signal iframe is on page
+  }
+);
 
-threeDSecureInstance.on('authentication-iframe-unavailable', function () {
+threeDSecureInstance.on("authentication-iframe-unavailable", function () {
   // Remove iframe from page
 });
 ```
@@ -112,12 +125,15 @@ threeDSecureInstance.on('authentication-iframe-unavailable', function () {
 ## SCA Exemptions
 
 ```javascript
-threeDSecureInstance.verifyCard({
-  nonce: nonce,
-  bin: bin,
-  amount: '10.00',
-  requestedExemptionType: 'low_value'  // or 'transaction_risk_analysis'
-}, callback);
+threeDSecureInstance.verifyCard(
+  {
+    nonce: nonce,
+    bin: bin,
+    amount: "10.00",
+    requestedExemptionType: "low_value", // or 'transaction_risk_analysis'
+  },
+  callback
+);
 ```
 
 Exemptions are requests -- the card issuer makes the final decision.
@@ -132,21 +148,22 @@ threeDSecureInstance.cancelVerifyCard(function (err, payload) {
 
 ## Common Errors
 
-| Code | Type | Fix |
-|------|------|-----|
-| `THREEDS_NOT_ENABLED` | MERCHANT | Enable 3D Secure in Braintree control panel |
-| `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY` | MERCHANT | Use client token instead |
-| `THREEDS_HTTPS_REQUIRED` | MERCHANT | Serve page over HTTPS |
-| `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED` | NETWORK | Check CSP allows `songbird.cardinalcommerce.com` |
-| `THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT` | UNKNOWN | Check network, retry |
-| `THREEDS_AUTHENTICATION_IN_PROGRESS` | MERCHANT | Wait for current verifyCard to complete |
-| `THREEDS_MISSING_VERIFY_CARD_OPTION` | MERCHANT | Provide nonce, bin, and amount |
-| `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | MERCHANT | Use fresh nonce (original may be consumed) |
-| `THREEDS_CARDINAL_SDK_CANCELED` | CUSTOMER | User closed challenge modal, allow retry |
+| Code                                            | Type     | Fix                                              |
+| ----------------------------------------------- | -------- | ------------------------------------------------ |
+| `THREEDS_NOT_ENABLED`                           | MERCHANT | Enable 3D Secure in Braintree control panel      |
+| `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY`          | MERCHANT | Use client token instead                         |
+| `THREEDS_HTTPS_REQUIRED`                        | MERCHANT | Serve page over HTTPS                            |
+| `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED`       | NETWORK  | Check CSP allows `songbird.cardinalcommerce.com` |
+| `THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT`           | UNKNOWN  | Check network, retry                             |
+| `THREEDS_AUTHENTICATION_IN_PROGRESS`            | MERCHANT | Wait for current verifyCard to complete          |
+| `THREEDS_MISSING_VERIFY_CARD_OPTION`            | MERCHANT | Provide nonce, bin, and amount                   |
+| `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | MERCHANT | Use fresh nonce (original may be consumed)       |
+| `THREEDS_CARDINAL_SDK_CANCELED`                 | CUSTOMER | User closed challenge modal, allow retry         |
 
 ## CSP Requirements
 
 Allow in Content-Security-Policy:
+
 - `script-src`: `https://songbird.cardinalcommerce.com`
 - `frame-src`: `https://songbird.cardinalcommerce.com`, `https://*.cardinalcommerce.com`
 - `connect-src`: `https://*.cardinalcommerce.com`

--- a/.well-known/agent-skills/skills/braintree-3d-secure.md
+++ b/.well-known/agent-skills/skills/braintree-3d-secure.md
@@ -1,0 +1,152 @@
+---
+name: braintree-3d-secure
+description: 3D Secure v2 authentication with Cardinal Commerce Songbird - verifyCard flow, challenge handling, SCA exemptions
+---
+
+# 3D Secure v2 Integration
+
+## Prerequisites
+
+- **HTTPS required** (production)
+- **Client token required** (not tokenization key)
+- **3D Secure enabled** in Braintree control panel
+- Only **version 2** supported (v1 removed)
+
+## Setup
+
+```javascript
+braintree.threeDSecure.create({
+  client: clientInstance,
+  version: '2',                    // Required: '2', '2-bootstrap3-modal', or '2-inline-iframe'
+  cardinalSDKConfig: {             // Optional
+    logging: { level: 'verbose' }, // 'on', 'verbose', 'off'
+    timeout: 10000,                // Cardinal API timeout (ms)
+    maxRequestRetries: 3
+  }
+}, function (err, threeDSecureInstance) {
+  // Ready
+});
+```
+
+## Authentication Flow
+
+```
+Tokenize card (Hosted Fields) -> verifyCard() -> lookup-complete event -> challenge (if needed) -> new nonce
+```
+
+**Important:** The nonce returned by `verifyCard` is NEW. The original nonce is consumed during lookup.
+
+### Step 1: Register Lookup Handler
+
+```javascript
+threeDSecureInstance.on('lookup-complete', function (data, next) {
+  // data.requiresUserAuthentication -- true if challenge needed
+  // data.threeDSecureInfo.liabilityShifted -- true if already shifted
+  // data.threeDSecureInfo.liabilityShiftPossible -- true if shift achievable
+
+  // MUST call next() to proceed (shows challenge modal if needed)
+  next();
+});
+```
+
+### Step 2: Verify Card
+
+```javascript
+threeDSecureInstance.verifyCard({
+  nonce: payload.nonce,        // From hostedFields.tokenize()
+  bin: payload.details.bin,    // Required: card BIN
+  amount: '100.00',           // Required: transaction amount
+
+  // Optional but recommended for better approval rates:
+  email: 'customer@example.com',
+  mobilePhoneNumber: '5551234567',
+  billingAddress: {
+    givenName: 'John',
+    surname: 'Doe',
+    streetAddress: '123 Main St',
+    locality: 'Chicago',
+    region: 'IL',
+    postalCode: '60606',
+    countryCodeAlpha2: 'US'
+  }
+}, function (err, verifyPayload) {
+  if (err) { console.error(err); return; }
+
+  // verifyPayload.nonce -- NEW nonce to send to server
+  // verifyPayload.threeDSecureInfo.liabilityShifted -- boolean
+  // verifyPayload.threeDSecureInfo.liabilityShiftPossible -- boolean
+  submitToServer(verifyPayload.nonce);
+});
+```
+
+## Outcome Scenarios
+
+| Scenario | requiresUserAuthentication | liabilityShifted | liabilityShiftPossible | Action |
+|----------|---------------------------|------------------|------------------------|--------|
+| Frictionless success | false | true | true | Use nonce, liability shifted |
+| Challenge required | true | false | true | Call `next()`, user completes challenge |
+| Not enrolled | false | false | false | Use nonce, seller assumes liability |
+| Auth failed | - | false | true | Decide whether to proceed without shift |
+
+## Framework Options
+
+| Version String | UI | Requirements |
+|---------------|-----|-------------|
+| `'2'` | Cardinal managed modal | None (default) |
+| `'2-bootstrap3-modal'` | Bootstrap 3 modal | Bootstrap 3 CSS/JS + jQuery loaded |
+| `'2-inline-iframe'` | Merchant-placed iframe | Handle `authentication-iframe-available` event |
+
+### Inline Iframe
+
+```javascript
+threeDSecureInstance.on('authentication-iframe-available', function (event, next) {
+  document.getElementById('3ds-container').appendChild(event.element);
+  next(); // Signal iframe is on page
+});
+
+threeDSecureInstance.on('authentication-iframe-unavailable', function () {
+  // Remove iframe from page
+});
+```
+
+## SCA Exemptions
+
+```javascript
+threeDSecureInstance.verifyCard({
+  nonce: nonce,
+  bin: bin,
+  amount: '10.00',
+  requestedExemptionType: 'low_value'  // or 'transaction_risk_analysis'
+}, callback);
+```
+
+Exemptions are requests -- the card issuer makes the final decision.
+
+## Cancellation
+
+```javascript
+threeDSecureInstance.cancelVerifyCard(function (err, payload) {
+  // payload.nonce: partially authenticated nonce (no liability shift)
+});
+```
+
+## Common Errors
+
+| Code | Type | Fix |
+|------|------|-----|
+| `THREEDS_NOT_ENABLED` | MERCHANT | Enable 3D Secure in Braintree control panel |
+| `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY` | MERCHANT | Use client token instead |
+| `THREEDS_HTTPS_REQUIRED` | MERCHANT | Serve page over HTTPS |
+| `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED` | NETWORK | Check CSP allows `songbird.cardinalcommerce.com` |
+| `THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT` | UNKNOWN | Check network, retry |
+| `THREEDS_AUTHENTICATION_IN_PROGRESS` | MERCHANT | Wait for current verifyCard to complete |
+| `THREEDS_MISSING_VERIFY_CARD_OPTION` | MERCHANT | Provide nonce, bin, and amount |
+| `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | MERCHANT | Use fresh nonce (original may be consumed) |
+| `THREEDS_CARDINAL_SDK_CANCELED` | CUSTOMER | User closed challenge modal, allow retry |
+
+## CSP Requirements
+
+Allow in Content-Security-Policy:
+- `script-src`: `https://songbird.cardinalcommerce.com`
+- `frame-src`: `https://songbird.cardinalcommerce.com`, `https://*.cardinalcommerce.com`
+- `connect-src`: `https://*.cardinalcommerce.com`

--- a/.well-known/agent-skills/skills/braintree-advanced-patterns.md
+++ b/.well-known/agent-skills/skills/braintree-advanced-patterns.md
@@ -1,0 +1,198 @@
+---
+name: braintree-advanced-patterns
+description: SDK internals and shared patterns - dual API, events, deferred client, Frame Service, CSP, analytics, teardown
+---
+
+# Advanced SDK patterns
+
+## Callback/Promise Dual API
+
+All public methods support both callbacks and Promises via `@braintree/wrap-promise`:
+
+```javascript
+// Callback style:
+component.create(options, function (err, instance) { /* ... */ });
+instance.tokenize(options, function (err, payload) { /* ... */ });
+
+// Promise style:
+component.create(options).then(function (instance) { /* ... */ });
+instance.tokenize(options).then(function (payload) { /* ... */ });
+```
+
+Both are equivalent. Do not provide both a callback and use `.then()`.
+
+## Event Emitter Pattern
+
+Complex components use `@braintree/event-emitter`:
+
+```javascript
+instance.on('eventName', function (data) { /* ... */ });
+instance.off('eventName', handler);
+```
+
+**Components with events:**
+- **Hosted Fields:** `focus`, `blur`, `validityChange`, `cardTypeChange`, `binAvailable`, `inputSubmitRequest`
+- **3D Secure:** `lookup-complete`, `authentication-modal-render`, `authentication-modal-close`, `authentication-iframe-available`, `authentication-iframe-unavailable`
+- **Venmo:** (internal events for flow coordination)
+
+Some events pass a `next` function for flow control:
+
+```javascript
+threeDSecureInstance.on('lookup-complete', function (data, next) {
+  // Inspect data, then call next() to proceed
+  next();
+});
+```
+
+## Deferred Client Creation
+
+Components can be created with `authorization` instead of `client`, deferring client creation:
+
+```javascript
+braintree.hostedFields.create({
+  authorization: CLIENT_TOKEN,     // Instead of client instance
+  fields: { /* ... */ }
+}).then(function (instance) {
+  // Client created internally, instance ready
+});
+```
+
+With `useDeferredClient: true`, the instance is available immediately but some methods return Promises instead of synchronous values:
+
+```javascript
+braintree.applePay.create({
+  authorization: CLIENT_TOKEN,
+  useDeferredClient: true
+}).then(function (applePayInstance) {
+  // Instance available immediately
+  // But createPaymentRequest returns a Promise:
+  applePayInstance.createPaymentRequest(options).then(function (request) { /* ... */ });
+});
+```
+
+## Frame Service Architecture
+
+Used by PayPal, Venmo, SEPA, and Local Payment for popup/modal flows.
+
+**Two-frame architecture:**
+1. **Dispatch frame** -- hidden iframe for message routing
+2. **Open frame** -- visible popup/modal for user interaction
+
+**Communication:** Uses `framebus` library for secure cross-origin postMessage.
+
+**Flow:**
+1. Component calls Frame Service to open popup/modal
+2. Frame Service creates dispatch iframe
+3. User interacts with external service (PayPal, bank, etc.)
+4. Result communicated back via framebus
+5. Frame Service closes popup, returns data to component
+
+**Popup vs redirect:** Frame Service supports both. Popup is preferred (no page navigation), redirect is fallback for environments that block popups.
+
+## Content Security Policy (CSP)
+
+### Hosted Fields
+
+```
+frame-src: https://assets.braintreegateway.com
+script-src: https://js.braintreegateway.com
+```
+
+### 3D Secure (Cardinal)
+
+```
+script-src: https://songbird.cardinalcommerce.com
+frame-src: https://songbird.cardinalcommerce.com https://*.cardinalcommerce.com
+connect-src: https://*.cardinalcommerce.com
+```
+
+### PayPal
+
+```
+script-src: https://www.paypal.com https://www.sandbox.paypal.com
+frame-src: https://www.paypal.com https://www.sandbox.paypal.com
+connect-src: https://www.paypal.com https://www.sandbox.paypal.com
+```
+
+### Venmo
+
+```
+connect-src: https://api.braintreegateway.com (GraphQL for polling)
+style-src: 'nonce-{value}' (use styleCspNonce option)
+img-src: data: (QR code canvas)
+```
+
+### Google Pay
+
+```
+script-src: https://pay.google.com
+frame-src: https://pay.google.com
+```
+
+### Apple Pay
+
+No additional CSP needed beyond standard Braintree domains.
+
+## Analytics Events
+
+Components send analytics for debugging and monitoring:
+
+```javascript
+var analytics = require('../lib/analytics');
+analytics.sendEvent(client, 'hosted-fields.tokenization.started');
+analytics.sendEvent(client, 'three-d-secure.verification.completed');
+```
+
+Event naming: `component-name.action.state`
+
+## Teardown Lifecycle
+
+All components support `teardown()` for cleanup:
+
+```javascript
+instance.teardown().then(function () {
+  // Event listeners removed
+  // Iframes removed from DOM
+  // Network connections closed
+  // Instance unusable after this
+});
+```
+
+Calling any method after teardown throws `METHOD_CALLED_AFTER_TEARDOWN`.
+
+**Multi-component teardown:**
+
+```javascript
+Promise.all([
+  hostedFieldsInstance.teardown(),
+  threeDSecureInstance.teardown(),
+  dataCollectorInstance.teardown()
+]).then(function () {
+  // All cleaned up, safe to create new instances
+});
+```
+
+## Client Caching
+
+The SDK caches client instances by authorization fingerprint. Multiple `client.create()` calls with the same authorization reuse the same gateway configuration, avoiding redundant network requests.
+
+## GraphQL Routing
+
+The client automatically routes requests to GraphQL when:
+1. GraphQL is enabled in gateway configuration
+2. The endpoint is in the enabled features list
+3. The request doesn't contain inputs incompatible with GraphQL (for example, UnionPay enrollment)
+
+No developer action needed -- routing is transparent.
+
+## Error Instance Properties
+
+```javascript
+// Every BraintreeError has:
+err.type       // 'CUSTOMER', 'MERCHANT', 'NETWORK', 'INTERNAL', 'UNKNOWN'
+err.code       // 'HOSTED_FIELDS_FIELDS_INVALID', etc.
+err.message    // Human-readable description
+err.details    // Optional: { originalError: Error, ... }
+```
+
+`err.details.originalError` often contains the underlying HTTP or SDK error with more context.

--- a/.well-known/agent-skills/skills/braintree-advanced-patterns.md
+++ b/.well-known/agent-skills/skills/braintree-advanced-patterns.md
@@ -11,12 +11,20 @@ All public methods support both callbacks and Promises via `@braintree/wrap-prom
 
 ```javascript
 // Callback style:
-component.create(options, function (err, instance) { /* ... */ });
-instance.tokenize(options, function (err, payload) { /* ... */ });
+component.create(options, function (err, instance) {
+  /* ... */
+});
+instance.tokenize(options, function (err, payload) {
+  /* ... */
+});
 
 // Promise style:
-component.create(options).then(function (instance) { /* ... */ });
-instance.tokenize(options).then(function (payload) { /* ... */ });
+component.create(options).then(function (instance) {
+  /* ... */
+});
+instance.tokenize(options).then(function (payload) {
+  /* ... */
+});
 ```
 
 Both are equivalent. Do not provide both a callback and use `.then()`.
@@ -26,11 +34,14 @@ Both are equivalent. Do not provide both a callback and use `.then()`.
 Complex components use `@braintree/event-emitter`:
 
 ```javascript
-instance.on('eventName', function (data) { /* ... */ });
-instance.off('eventName', handler);
+instance.on("eventName", function (data) {
+  /* ... */
+});
+instance.off("eventName", handler);
 ```
 
 **Components with events:**
+
 - **Hosted Fields:** `focus`, `blur`, `validityChange`, `cardTypeChange`, `binAvailable`, `inputSubmitRequest`
 - **3D Secure:** `lookup-complete`, `authentication-modal-render`, `authentication-modal-close`, `authentication-iframe-available`, `authentication-iframe-unavailable`
 - **Venmo:** (internal events for flow coordination)
@@ -38,7 +49,7 @@ instance.off('eventName', handler);
 Some events pass a `next` function for flow control:
 
 ```javascript
-threeDSecureInstance.on('lookup-complete', function (data, next) {
+threeDSecureInstance.on("lookup-complete", function (data, next) {
   // Inspect data, then call next() to proceed
   next();
 });
@@ -49,25 +60,33 @@ threeDSecureInstance.on('lookup-complete', function (data, next) {
 Components can be created with `authorization` instead of `client`, deferring client creation:
 
 ```javascript
-braintree.hostedFields.create({
-  authorization: CLIENT_TOKEN,     // Instead of client instance
-  fields: { /* ... */ }
-}).then(function (instance) {
-  // Client created internally, instance ready
-});
+braintree.hostedFields
+  .create({
+    authorization: CLIENT_TOKEN, // Instead of client instance
+    fields: {
+      /* ... */
+    },
+  })
+  .then(function (instance) {
+    // Client created internally, instance ready
+  });
 ```
 
 With `useDeferredClient: true`, the instance is available immediately but some methods return Promises instead of synchronous values:
 
 ```javascript
-braintree.applePay.create({
-  authorization: CLIENT_TOKEN,
-  useDeferredClient: true
-}).then(function (applePayInstance) {
-  // Instance available immediately
-  // But createPaymentRequest returns a Promise:
-  applePayInstance.createPaymentRequest(options).then(function (request) { /* ... */ });
-});
+braintree.applePay
+  .create({
+    authorization: CLIENT_TOKEN,
+    useDeferredClient: true,
+  })
+  .then(function (applePayInstance) {
+    // Instance available immediately
+    // But createPaymentRequest returns a Promise:
+    applePayInstance.createPaymentRequest(options).then(function (request) {
+      /* ... */
+    });
+  });
 ```
 
 ## Frame Service Architecture
@@ -75,12 +94,14 @@ braintree.applePay.create({
 Used by PayPal, Venmo, SEPA, and Local Payment for popup/modal flows.
 
 **Two-frame architecture:**
+
 1. **Dispatch frame** -- hidden iframe for message routing
 2. **Open frame** -- visible popup/modal for user interaction
 
 **Communication:** Uses `framebus` library for secure cross-origin postMessage.
 
 **Flow:**
+
 1. Component calls Frame Service to open popup/modal
 2. Frame Service creates dispatch iframe
 3. User interacts with external service (PayPal, bank, etc.)
@@ -96,14 +117,16 @@ Used by PayPal, Venmo, SEPA, and Local Payment for popup/modal flows.
 ```
 frame-src: https://assets.braintreegateway.com
 script-src: https://js.braintreegateway.com
+style-src: 'unsafe-inline'
+connect-src: https://*.braintreegateway.com https://*.braintree-api.com
 ```
 
 ### 3D Secure (Cardinal)
 
 ```
-script-src: https://songbird.cardinalcommerce.com
+script-src: https://songbird.cardinalcommerce.com https://songbirdstag.cardinalcommerce.com
 frame-src: https://songbird.cardinalcommerce.com https://*.cardinalcommerce.com
-connect-src: https://*.cardinalcommerce.com
+connect-src: https://*.cardinalcommerce.com https://cardinaltrusted.com
 ```
 
 ### PayPal
@@ -129,6 +152,14 @@ script-src: https://pay.google.com
 frame-src: https://pay.google.com
 ```
 
+### Data Collector / FraudNet
+
+```
+script-src: https://*.paypalobjects.com 'unsafe-eval'
+```
+
+**Note:** FraudNet uses `eval()` internally, requiring `'unsafe-eval'` in `script-src`.
+
 ### Apple Pay
 
 No additional CSP needed beyond standard Braintree domains.
@@ -138,9 +169,9 @@ No additional CSP needed beyond standard Braintree domains.
 Components send analytics for debugging and monitoring:
 
 ```javascript
-var analytics = require('../lib/analytics');
-analytics.sendEvent(client, 'hosted-fields.tokenization.started');
-analytics.sendEvent(client, 'three-d-secure.verification.completed');
+var analytics = require("../lib/analytics");
+analytics.sendEvent(client, "hosted-fields.tokenization.started");
+analytics.sendEvent(client, "three-d-secure.verification.completed");
 ```
 
 Event naming: `component-name.action.state`
@@ -166,7 +197,7 @@ Calling any method after teardown throws `METHOD_CALLED_AFTER_TEARDOWN`.
 Promise.all([
   hostedFieldsInstance.teardown(),
   threeDSecureInstance.teardown(),
-  dataCollectorInstance.teardown()
+  dataCollectorInstance.teardown(),
 ]).then(function () {
   // All cleaned up, safe to create new instances
 });
@@ -179,6 +210,7 @@ The SDK caches client instances by authorization fingerprint. Multiple `client.c
 ## GraphQL Routing
 
 The client automatically routes requests to GraphQL when:
+
 1. GraphQL is enabled in gateway configuration
 2. The endpoint is in the enabled features list
 3. The request doesn't contain inputs incompatible with GraphQL (for example, UnionPay enrollment)
@@ -189,10 +221,10 @@ No developer action needed -- routing is transparent.
 
 ```javascript
 // Every BraintreeError has:
-err.type       // 'CUSTOMER', 'MERCHANT', 'NETWORK', 'INTERNAL', 'UNKNOWN'
-err.code       // 'HOSTED_FIELDS_FIELDS_INVALID', etc.
-err.message    // Human-readable description
-err.details    // Optional: { originalError: Error, ... }
+err.type; // 'CUSTOMER', 'MERCHANT', 'NETWORK', 'INTERNAL', 'UNKNOWN'
+err.code; // 'HOSTED_FIELDS_FIELDS_INVALID', etc.
+err.message; // Human-readable description
+err.details; // Optional: { originalError: Error, ... }
 ```
 
 `err.details.originalError` often contains the underlying HTTP or SDK error with more context.

--- a/.well-known/agent-skills/skills/braintree-alternative-payments.md
+++ b/.well-known/agent-skills/skills/braintree-alternative-payments.md
@@ -12,47 +12,52 @@ Supports 25+ methods including iDEAL, Sofort, Bancontact, BLIK, Giropay, EPS, Mu
 ### Setup
 
 ```javascript
-braintree.localPayment.create({
-  client: clientInstance,
-  merchantAccountId: 'EUR_merchant_account'  // Required for multi-currency
-}).then(function (localPaymentInstance) {
-  // Ready
-});
+braintree.localPayment
+  .create({
+    client: clientInstance,
+    merchantAccountId: "EUR_merchant_account", // Required for multi-currency
+  })
+  .then(function (localPaymentInstance) {
+    // Ready
+  });
 ```
 
 ### Payment Flow (Popup)
 
 ```javascript
 // MUST be called from click handler (popup blocker prevention)
-payButton.addEventListener('click', function () {
-  localPaymentInstance.startPayment({
-    paymentType: 'ideal',              // Required: payment method type
-    amount: '10.00',                   // Required
-    currencyCode: 'EUR',               // Required
-    paymentTypeCountryCode: 'NL',      // Required for some methods
-    email: 'customer@example.com',
-    givenName: 'John',
-    surname: 'Doe',
-    address: {
-      streetAddress: '123 Main St',
-      locality: 'Amsterdam',
-      postalCode: '1012',
-      countryCode: 'NL'
+payButton.addEventListener("click", function () {
+  localPaymentInstance.startPayment(
+    {
+      paymentType: "ideal", // Required: payment method type
+      amount: "10.00", // Required
+      currencyCode: "EUR", // Required
+      paymentTypeCountryCode: "NL", // Required for some methods
+      email: "customer@example.com",
+      givenName: "John",
+      surname: "Doe",
+      address: {
+        streetAddress: "123 Main St",
+        locality: "Amsterdam",
+        postalCode: "1012",
+        countryCode: "NL",
+      },
+      fallback: {
+        url: "https://example.com/callback", // Redirect fallback URL
+        buttonText: "Return to Merchant",
+      },
+      shippingAddressRequired: false,
     },
-    fallback: {
-      url: 'https://example.com/callback',     // Redirect fallback URL
-      buttonText: 'Return to Merchant'
-    },
-    shippingAddressRequired: false
-  }, function (err, payload) {
-    if (err) {
-      if (err.code === 'LOCAL_PAYMENT_CANCELED') return;
-      console.error(err);
-      return;
+    function (err, payload) {
+      if (err) {
+        if (err.code === "LOCAL_PAYMENT_CANCELED") return;
+        console.error(err);
+        return;
+      }
+      // payload.nonce -- send to server
+      submitNonceToServer(payload.nonce);
     }
-    // payload.nonce -- send to server
-    submitNonceToServer(payload.nonce);
-  });
+  );
 });
 ```
 
@@ -61,22 +66,26 @@ payButton.addEventListener('click', function () {
 For environments where popups are blocked:
 
 ```javascript
-localPaymentInstance.startPayment({
-  paymentType: 'sofort',
-  amount: '25.00',
-  currencyCode: 'EUR',
-  paymentTypeCountryCode: 'DE',
-  fallback: {
-    url: 'https://example.com/local-payment-callback',
-    buttonText: 'Complete Payment'
-  }
-}).then(function (payload) {
-  // Redirected to bank, then back to fallback URL
-  // On return page, tokenize using query params
-});
+localPaymentInstance
+  .startPayment({
+    paymentType: "sofort",
+    amount: "25.00",
+    currencyCode: "EUR",
+    paymentTypeCountryCode: "DE",
+    fallback: {
+      url: "https://example.com/local-payment-callback",
+      buttonText: "Complete Payment",
+    },
+  })
+  .then(function (payload) {
+    // Redirected to bank, then back to fallback URL
+    // On return page, tokenize using query params
+  });
 
 // On return page:
-localPaymentInstance.tokenize({ /* query params */ });
+localPaymentInstance.tokenize({
+  /* query params */
+});
 ```
 
 ### Deferred Payment Types
@@ -92,40 +101,44 @@ Some methods (Multibanco, OXXO) return a reference for offline payment:
 ### Setup
 
 ```javascript
-braintree.sepa.create({
-  client: clientInstance
-}).then(function (sepaInstance) {
-  // Ready
-});
+braintree.sepa
+  .create({
+    client: clientInstance,
+  })
+  .then(function (sepaInstance) {
+    // Ready
+  });
 ```
 
 ### Payment Flow
 
 ```javascript
-payButton.addEventListener('click', function () {
-  sepaInstance.tokenize({
-    mandateType: 'ONE_OFF',             // or 'RECURRENT'
-    customerBillingAddress: {
-      streetAddress: '123 Hauptstrasse',
-      locality: 'Berlin',
-      region: 'BE',
-      postalCode: '10115',
-      countryCode: 'DE'
-    },
-    customerInfo: {
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'john@example.com',
-      customerId: 'customer-123'
-    },
-    iban: 'DE89370400440532013000',
-    merchantAccountId: 'EUR_merchant_account'
-  }).then(function (payload) {
-    // payload.nonce -- send to server
-    // payload.details.ibanLastFour
-    // payload.details.mandateType
-    submitNonceToServer(payload.nonce);
-  });
+payButton.addEventListener("click", function () {
+  sepaInstance
+    .tokenize({
+      mandateType: "ONE_OFF", // or 'RECURRENT'
+      customerBillingAddress: {
+        streetAddress: "123 Hauptstrasse",
+        locality: "Berlin",
+        region: "BE",
+        postalCode: "10115",
+        countryCode: "DE",
+      },
+      customerInfo: {
+        firstName: "John",
+        lastName: "Doe",
+        email: "john@example.com",
+        customerId: "customer-123",
+      },
+      iban: "DE89370400440532013000",
+      merchantAccountId: "EUR_merchant_account",
+    })
+    .then(function (payload) {
+      // payload.nonce -- send to server
+      // payload.details.ibanLastFour
+      // payload.details.mandateType
+      submitNonceToServer(payload.nonce);
+    });
 });
 ```
 
@@ -134,43 +147,49 @@ payButton.addEventListener('click', function () {
 ### Setup
 
 ```javascript
-braintree.usBankAccount.create({
-  client: clientInstance
-}).then(function (usBankAccountInstance) {
-  // Ready
-});
+braintree.usBankAccount
+  .create({
+    client: clientInstance,
+  })
+  .then(function (usBankAccountInstance) {
+    // Ready
+  });
 ```
 
 ### Bank Login (Plaid)
 
 ```javascript
-usBankAccountInstance.tokenize({
-  bankLogin: {
-    displayName: 'My Store'
-  },
-  mandateText: 'I authorize Braintree to debit my bank account.'
-}).then(function (payload) {
-  // payload.nonce
-  // payload.details.bankName, payload.details.accountType
-});
+usBankAccountInstance
+  .tokenize({
+    bankLogin: {
+      displayName: "My Store",
+    },
+    mandateText: "I authorize Braintree to debit my bank account.",
+  })
+  .then(function (payload) {
+    // payload.nonce
+    // payload.details.bankName, payload.details.accountType
+  });
 ```
 
 ### Manual Entry
 
 ```javascript
-usBankAccountInstance.tokenize({
-  bankDetails: {
-    accountNumber: '1000000000',
-    routingNumber: '011000015',
-    accountType: 'checking',          // or 'savings'
-    ownershipType: 'personal',        // or 'business'
-    firstName: 'John',
-    lastName: 'Doe'
-  },
-  mandateText: 'I authorize Braintree to debit my bank account.'
-}).then(function (payload) {
-  // payload.nonce
-});
+usBankAccountInstance
+  .tokenize({
+    bankDetails: {
+      accountNumber: "1000000000",
+      routingNumber: "011000015",
+      accountType: "checking", // or 'savings'
+      ownershipType: "personal", // or 'business'
+      firstName: "John",
+      lastName: "Doe",
+    },
+    mandateText: "I authorize Braintree to debit my bank account.",
+  })
+  .then(function (payload) {
+    // payload.nonce
+  });
 ```
 
 ## Common Patterns
@@ -184,11 +203,11 @@ All alternative payment methods share these patterns:
 
 ## Key Errors
 
-| Code | Type | Fix |
-|------|------|-----|
-| `LOCAL_PAYMENT_NOT_ENABLED` | MERCHANT | Enable Local Payment in control panel |
-| `LOCAL_PAYMENT_CANCELED` | CUSTOMER | User cancelled, allow retry |
-| `LOCAL_PAYMENT_POPUP_OPEN_FAILED` | MERCHANT | Call from click handler |
-| `LOCAL_PAYMENT_START_PAYMENT_FAILED` | NETWORK | Check network, retry |
-| `SEPA_NOT_ENABLED` | MERCHANT | Enable SEPA in control panel |
-| `US_BANK_ACCOUNT_NOT_ENABLED` | MERCHANT | Enable US Bank Account in control panel |
+| Code                                 | Type     | Fix                                     |
+| ------------------------------------ | -------- | --------------------------------------- |
+| `LOCAL_PAYMENT_NOT_ENABLED`          | MERCHANT | Enable Local Payment in control panel   |
+| `LOCAL_PAYMENT_CANCELED`             | CUSTOMER | User cancelled, allow retry             |
+| `LOCAL_PAYMENT_POPUP_OPEN_FAILED`    | MERCHANT | Call from click handler                 |
+| `LOCAL_PAYMENT_START_PAYMENT_FAILED` | NETWORK  | Check network, retry                    |
+| `SEPA_NOT_ENABLED`                   | MERCHANT | Enable SEPA in control panel            |
+| `US_BANK_ACCOUNT_NOT_ENABLED`        | MERCHANT | Enable US Bank Account in control panel |

--- a/.well-known/agent-skills/skills/braintree-alternative-payments.md
+++ b/.well-known/agent-skills/skills/braintree-alternative-payments.md
@@ -1,0 +1,194 @@
+---
+name: braintree-alternative-payments
+description: Local payment methods (iDEAL, Sofort, Bancontact, BLIK), SEPA Direct Debit, and US Bank Account (ACH) integration
+---
+
+# Alternative Payment Methods
+
+## Local Payment Methods
+
+Supports 25+ methods including iDEAL, Sofort, Bancontact, BLIK, Giropay, EPS, Multibanco, MyBank, P24, and more.
+
+### Setup
+
+```javascript
+braintree.localPayment.create({
+  client: clientInstance,
+  merchantAccountId: 'EUR_merchant_account'  // Required for multi-currency
+}).then(function (localPaymentInstance) {
+  // Ready
+});
+```
+
+### Payment Flow (Popup)
+
+```javascript
+// MUST be called from click handler (popup blocker prevention)
+payButton.addEventListener('click', function () {
+  localPaymentInstance.startPayment({
+    paymentType: 'ideal',              // Required: payment method type
+    amount: '10.00',                   // Required
+    currencyCode: 'EUR',               // Required
+    paymentTypeCountryCode: 'NL',      // Required for some methods
+    email: 'customer@example.com',
+    givenName: 'John',
+    surname: 'Doe',
+    address: {
+      streetAddress: '123 Main St',
+      locality: 'Amsterdam',
+      postalCode: '1012',
+      countryCode: 'NL'
+    },
+    fallback: {
+      url: 'https://example.com/callback',     // Redirect fallback URL
+      buttonText: 'Return to Merchant'
+    },
+    shippingAddressRequired: false
+  }, function (err, payload) {
+    if (err) {
+      if (err.code === 'LOCAL_PAYMENT_CANCELED') return;
+      console.error(err);
+      return;
+    }
+    // payload.nonce -- send to server
+    submitNonceToServer(payload.nonce);
+  });
+});
+```
+
+### Redirect Flow
+
+For environments where popups are blocked:
+
+```javascript
+localPaymentInstance.startPayment({
+  paymentType: 'sofort',
+  amount: '25.00',
+  currencyCode: 'EUR',
+  paymentTypeCountryCode: 'DE',
+  fallback: {
+    url: 'https://example.com/local-payment-callback',
+    buttonText: 'Complete Payment'
+  }
+}).then(function (payload) {
+  // Redirected to bank, then back to fallback URL
+  // On return page, tokenize using query params
+});
+
+// On return page:
+localPaymentInstance.tokenize({ /* query params */ });
+```
+
+### Deferred Payment Types
+
+Some methods (Multibanco, OXXO) return a reference for offline payment:
+
+```javascript
+// payload.details contains payment reference information
+```
+
+## SEPA Direct Debit
+
+### Setup
+
+```javascript
+braintree.sepa.create({
+  client: clientInstance
+}).then(function (sepaInstance) {
+  // Ready
+});
+```
+
+### Payment Flow
+
+```javascript
+payButton.addEventListener('click', function () {
+  sepaInstance.tokenize({
+    mandateType: 'ONE_OFF',             // or 'RECURRENT'
+    customerBillingAddress: {
+      streetAddress: '123 Hauptstrasse',
+      locality: 'Berlin',
+      region: 'BE',
+      postalCode: '10115',
+      countryCode: 'DE'
+    },
+    customerInfo: {
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@example.com',
+      customerId: 'customer-123'
+    },
+    iban: 'DE89370400440532013000',
+    merchantAccountId: 'EUR_merchant_account'
+  }).then(function (payload) {
+    // payload.nonce -- send to server
+    // payload.details.ibanLastFour
+    // payload.details.mandateType
+    submitNonceToServer(payload.nonce);
+  });
+});
+```
+
+## US Bank Account (ACH)
+
+### Setup
+
+```javascript
+braintree.usBankAccount.create({
+  client: clientInstance
+}).then(function (usBankAccountInstance) {
+  // Ready
+});
+```
+
+### Bank Login (Plaid)
+
+```javascript
+usBankAccountInstance.tokenize({
+  bankLogin: {
+    displayName: 'My Store'
+  },
+  mandateText: 'I authorize Braintree to debit my bank account.'
+}).then(function (payload) {
+  // payload.nonce
+  // payload.details.bankName, payload.details.accountType
+});
+```
+
+### Manual Entry
+
+```javascript
+usBankAccountInstance.tokenize({
+  bankDetails: {
+    accountNumber: '1000000000',
+    routingNumber: '011000015',
+    accountType: 'checking',          // or 'savings'
+    ownershipType: 'personal',        // or 'business'
+    firstName: 'John',
+    lastName: 'Doe'
+  },
+  mandateText: 'I authorize Braintree to debit my bank account.'
+}).then(function (payload) {
+  // payload.nonce
+});
+```
+
+## Common Patterns
+
+All alternative payment methods share these patterns:
+
+1. **Frame Service architecture** -- popups/modals managed by Braintree's frame service
+2. **Click handler requirement** -- `startPayment`/`tokenize` must be called from user interaction
+3. **Nonce-based** -- all return a nonce to send to your server
+4. **Merchant account** -- multi-currency setups require `merchantAccountId`
+
+## Key Errors
+
+| Code | Type | Fix |
+|------|------|-----|
+| `LOCAL_PAYMENT_NOT_ENABLED` | MERCHANT | Enable Local Payment in control panel |
+| `LOCAL_PAYMENT_CANCELED` | CUSTOMER | User cancelled, allow retry |
+| `LOCAL_PAYMENT_POPUP_OPEN_FAILED` | MERCHANT | Call from click handler |
+| `LOCAL_PAYMENT_START_PAYMENT_FAILED` | NETWORK | Check network, retry |
+| `SEPA_NOT_ENABLED` | MERCHANT | Enable SEPA in control panel |
+| `US_BANK_ACCOUNT_NOT_ENABLED` | MERCHANT | Enable US Bank Account in control panel |

--- a/.well-known/agent-skills/skills/braintree-apple-pay.md
+++ b/.well-known/agent-skills/skills/braintree-apple-pay.md
@@ -1,0 +1,134 @@
+---
+name: braintree-apple-pay
+description: Apple Pay web integration via ApplePaySession - payment requests, merchant validation, and tokenization
+---
+
+# Apple Pay Integration
+
+## Prerequisites
+
+- Apple Developer account with Merchant ID
+- Domain registered in both Apple Developer portal and Braintree control panel
+- HTTPS required (localhost OK for development)
+- Safari 10+ on macOS/iOS only
+- User has Apple Pay configured with valid card
+
+## Complete Flow
+
+```javascript
+// 1. Check availability
+if (!window.ApplePaySession || !ApplePaySession.canMakePayments()) {
+  return; // Apple Pay not available
+}
+
+// 2. Create instance
+braintree.applePay.create({
+  client: clientInstance
+}).then(function (applePayInstance) {
+
+  document.getElementById('apple-pay-button').addEventListener('click', function () {
+
+    // 3. Create payment request (MUST be synchronous in click handler)
+    var paymentRequest = applePayInstance.createPaymentRequest({
+      total: { label: 'My Store', amount: '19.99' }
+    });
+
+    // 4. Create session (MUST be in direct click handler, not async callback)
+    var session = new ApplePaySession(3, paymentRequest);
+
+    // 5. Merchant validation
+    session.onvalidatemerchant = function (event) {
+      applePayInstance.performValidation({
+        validationURL: event.validationURL,
+        displayName: 'My Store'
+      }).then(function (merchantSession) {
+        session.completeMerchantValidation(merchantSession);
+      }).catch(function (err) {
+        session.abort();
+      });
+    };
+
+    // 6. Payment authorization
+    session.onpaymentauthorized = function (event) {
+      applePayInstance.tokenize({
+        token: event.payment.token
+      }).then(function (payload) {
+        // payload.nonce, payload.details.cardType, payload.details.dpanLastTwo
+        return submitToServer(payload.nonce);
+      }).then(function () {
+        session.completePayment(ApplePaySession.STATUS_SUCCESS);
+      }).catch(function () {
+        session.completePayment(ApplePaySession.STATUS_FAILURE);
+      });
+    };
+
+    session.oncancel = function () { /* user cancelled */ };
+
+    session.begin();
+  });
+});
+```
+
+## Payment Request Options
+
+```javascript
+applePayInstance.createPaymentRequest({
+  total: { label: 'My Store', amount: '22.00', type: 'final' },
+  lineItems: [
+    { label: 'Subtotal', amount: '20.00' },
+    { label: 'Shipping', amount: '2.00' }
+  ],
+  shippingMethods: [
+    { label: 'Standard', detail: '5-7 days', amount: '2.00', identifier: 'standard' },
+    { label: 'Express', detail: '2-3 days', amount: '5.00', identifier: 'express' }
+  ],
+  requiredBillingContactFields: ['postalAddress', 'email'],
+  requiredShippingContactFields: ['postalAddress', 'phone', 'email', 'name'],
+  shippingType: 'shipping'   // 'shipping', 'delivery', 'storePickup', 'servicePickup'
+});
+// The SDK automatically includes: countryCode, currencyCode, merchantCapabilities, supportedNetworks
+```
+
+## Shipping Selection
+
+```javascript
+session.onshippingmethodselected = function (event) {
+  var shipping = parseFloat(event.shippingMethod.amount);
+  session.completeShippingMethodSelection({
+    newTotal: { label: 'My Store', amount: (subtotal + shipping).toFixed(2) },
+    newLineItems: [
+      { label: 'Subtotal', amount: subtotal.toFixed(2) },
+      { label: event.shippingMethod.label, amount: event.shippingMethod.amount }
+    ]
+  });
+};
+```
+
+## Common Errors
+
+| Code | Type | Fix |
+|------|------|-----|
+| `APPLE_PAY_NOT_ENABLED` | MERCHANT | Enable Apple Pay in Braintree control panel |
+| `APPLE_PAY_VALIDATION_URL_REQUIRED` | MERCHANT | Pass `event.validationURL` to `performValidation` |
+| `APPLE_PAY_MERCHANT_VALIDATION_FAILED` | MERCHANT | Register exact domain (including subdomain) in Braintree |
+| `APPLE_PAY_MERCHANT_VALIDATION_NETWORK` | NETWORK | Check network, retry |
+| `APPLE_PAY_PAYMENT_TOKEN_REQUIRED` | MERCHANT | Pass `event.payment.token` to `tokenize` |
+| `APPLE_PAY_TOKENIZATION` | NETWORK | Check network, retry |
+
+## Important: Session timing
+
+`new ApplePaySession()` **must** be created synchronously in the click handler. Creating it inside an async callback (Promise `.then`, `setTimeout`, `fetch.then`) will throw:
+
+> "Must create a new ApplePaySession from a user gesture handler"
+
+Async work (validation, tokenization) can happen inside the session event handlers.
+
+## Merchant Identifier
+
+```javascript
+// Check if user has active Apple Pay card
+ApplePaySession.canMakePaymentsWithActiveCard(applePayInstance.merchantIdentifier)
+  .then(function (canMake) {
+    if (canMake) { /* show button */ }
+  });
+```

--- a/.well-known/agent-skills/skills/braintree-apple-pay.md
+++ b/.well-known/agent-skills/skills/braintree-apple-pay.md
@@ -22,69 +22,90 @@ if (!window.ApplePaySession || !ApplePaySession.canMakePayments()) {
 }
 
 // 2. Create instance
-braintree.applePay.create({
-  client: clientInstance
-}).then(function (applePayInstance) {
+braintree.applePay
+  .create({
+    client: clientInstance,
+  })
+  .then(function (applePayInstance) {
+    document
+      .getElementById("apple-pay-button")
+      .addEventListener("click", function () {
+        // 3. Create payment request (MUST be synchronous in click handler)
+        var paymentRequest = applePayInstance.createPaymentRequest({
+          total: { label: "My Store", amount: "19.99" },
+        });
 
-  document.getElementById('apple-pay-button').addEventListener('click', function () {
+        // 4. Create session (MUST be in direct click handler, not async callback)
+        var session = new ApplePaySession(3, paymentRequest);
 
-    // 3. Create payment request (MUST be synchronous in click handler)
-    var paymentRequest = applePayInstance.createPaymentRequest({
-      total: { label: 'My Store', amount: '19.99' }
-    });
+        // 5. Merchant validation
+        session.onvalidatemerchant = function (event) {
+          applePayInstance
+            .performValidation({
+              validationURL: event.validationURL,
+              displayName: "My Store",
+            })
+            .then(function (merchantSession) {
+              session.completeMerchantValidation(merchantSession);
+            })
+            .catch(function (err) {
+              session.abort();
+            });
+        };
 
-    // 4. Create session (MUST be in direct click handler, not async callback)
-    var session = new ApplePaySession(3, paymentRequest);
+        // 6. Payment authorization
+        session.onpaymentauthorized = function (event) {
+          applePayInstance
+            .tokenize({
+              token: event.payment.token,
+            })
+            .then(function (payload) {
+              // payload.nonce, payload.details.cardType, payload.details.dpanLastTwo
+              return submitToServer(payload.nonce);
+            })
+            .then(function () {
+              session.completePayment(ApplePaySession.STATUS_SUCCESS);
+            })
+            .catch(function () {
+              session.completePayment(ApplePaySession.STATUS_FAILURE);
+            });
+        };
 
-    // 5. Merchant validation
-    session.onvalidatemerchant = function (event) {
-      applePayInstance.performValidation({
-        validationURL: event.validationURL,
-        displayName: 'My Store'
-      }).then(function (merchantSession) {
-        session.completeMerchantValidation(merchantSession);
-      }).catch(function (err) {
-        session.abort();
+        session.oncancel = function () {
+          /* user cancelled */
+        };
+
+        session.begin();
       });
-    };
-
-    // 6. Payment authorization
-    session.onpaymentauthorized = function (event) {
-      applePayInstance.tokenize({
-        token: event.payment.token
-      }).then(function (payload) {
-        // payload.nonce, payload.details.cardType, payload.details.dpanLastTwo
-        return submitToServer(payload.nonce);
-      }).then(function () {
-        session.completePayment(ApplePaySession.STATUS_SUCCESS);
-      }).catch(function () {
-        session.completePayment(ApplePaySession.STATUS_FAILURE);
-      });
-    };
-
-    session.oncancel = function () { /* user cancelled */ };
-
-    session.begin();
   });
-});
 ```
 
 ## Payment Request Options
 
 ```javascript
 applePayInstance.createPaymentRequest({
-  total: { label: 'My Store', amount: '22.00', type: 'final' },
+  total: { label: "My Store", amount: "22.00", type: "final" },
   lineItems: [
-    { label: 'Subtotal', amount: '20.00' },
-    { label: 'Shipping', amount: '2.00' }
+    { label: "Subtotal", amount: "20.00" },
+    { label: "Shipping", amount: "2.00" },
   ],
   shippingMethods: [
-    { label: 'Standard', detail: '5-7 days', amount: '2.00', identifier: 'standard' },
-    { label: 'Express', detail: '2-3 days', amount: '5.00', identifier: 'express' }
+    {
+      label: "Standard",
+      detail: "5-7 days",
+      amount: "2.00",
+      identifier: "standard",
+    },
+    {
+      label: "Express",
+      detail: "2-3 days",
+      amount: "5.00",
+      identifier: "express",
+    },
   ],
-  requiredBillingContactFields: ['postalAddress', 'email'],
-  requiredShippingContactFields: ['postalAddress', 'phone', 'email', 'name'],
-  shippingType: 'shipping'   // 'shipping', 'delivery', 'storePickup', 'servicePickup'
+  requiredBillingContactFields: ["postalAddress", "email"],
+  requiredShippingContactFields: ["postalAddress", "phone", "email", "name"],
+  shippingType: "shipping", // 'shipping', 'delivery', 'storePickup', 'servicePickup'
 });
 // The SDK automatically includes: countryCode, currencyCode, merchantCapabilities, supportedNetworks
 ```
@@ -95,25 +116,28 @@ applePayInstance.createPaymentRequest({
 session.onshippingmethodselected = function (event) {
   var shipping = parseFloat(event.shippingMethod.amount);
   session.completeShippingMethodSelection({
-    newTotal: { label: 'My Store', amount: (subtotal + shipping).toFixed(2) },
+    newTotal: { label: "My Store", amount: (subtotal + shipping).toFixed(2) },
     newLineItems: [
-      { label: 'Subtotal', amount: subtotal.toFixed(2) },
-      { label: event.shippingMethod.label, amount: event.shippingMethod.amount }
-    ]
+      { label: "Subtotal", amount: subtotal.toFixed(2) },
+      {
+        label: event.shippingMethod.label,
+        amount: event.shippingMethod.amount,
+      },
+    ],
   });
 };
 ```
 
 ## Common Errors
 
-| Code | Type | Fix |
-|------|------|-----|
-| `APPLE_PAY_NOT_ENABLED` | MERCHANT | Enable Apple Pay in Braintree control panel |
-| `APPLE_PAY_VALIDATION_URL_REQUIRED` | MERCHANT | Pass `event.validationURL` to `performValidation` |
-| `APPLE_PAY_MERCHANT_VALIDATION_FAILED` | MERCHANT | Register exact domain (including subdomain) in Braintree |
-| `APPLE_PAY_MERCHANT_VALIDATION_NETWORK` | NETWORK | Check network, retry |
-| `APPLE_PAY_PAYMENT_TOKEN_REQUIRED` | MERCHANT | Pass `event.payment.token` to `tokenize` |
-| `APPLE_PAY_TOKENIZATION` | NETWORK | Check network, retry |
+| Code                                    | Type     | Fix                                                      |
+| --------------------------------------- | -------- | -------------------------------------------------------- |
+| `APPLE_PAY_NOT_ENABLED`                 | MERCHANT | Enable Apple Pay in Braintree control panel              |
+| `APPLE_PAY_VALIDATION_URL_REQUIRED`     | MERCHANT | Pass `event.validationURL` to `performValidation`        |
+| `APPLE_PAY_MERCHANT_VALIDATION_FAILED`  | MERCHANT | Register exact domain (including subdomain) in Braintree |
+| `APPLE_PAY_MERCHANT_VALIDATION_NETWORK` | NETWORK  | Check network, retry                                     |
+| `APPLE_PAY_PAYMENT_TOKEN_REQUIRED`      | MERCHANT | Pass `event.payment.token` to `tokenize`                 |
+| `APPLE_PAY_TOKENIZATION`                | NETWORK  | Check network, retry                                     |
 
 ## Important: Session timing
 
@@ -127,8 +151,11 @@ Async work (validation, tokenization) can happen inside the session event handle
 
 ```javascript
 // Check if user has active Apple Pay card
-ApplePaySession.canMakePaymentsWithActiveCard(applePayInstance.merchantIdentifier)
-  .then(function (canMake) {
-    if (canMake) { /* show button */ }
-  });
+ApplePaySession.canMakePaymentsWithActiveCard(
+  applePayInstance.merchantIdentifier
+).then(function (canMake) {
+  if (canMake) {
+    /* show button */
+  }
+});
 ```

--- a/.well-known/agent-skills/skills/braintree-card-payment-full.md
+++ b/.well-known/agent-skills/skills/braintree-card-payment-full.md
@@ -1,0 +1,173 @@
+---
+name: braintree-card-payment-full
+description: End-to-end card payment orchestration combining Hosted Fields, 3D Secure, and Data Collector
+---
+
+# Complete Card Payment Flow
+
+This skill covers the most common production integration: collect card data, gather device fingerprint, tokenize, authenticate with 3DS, and submit nonce to server.
+
+## Components Needed
+
+1. **Client** -- foundational, required by all others
+2. **Hosted Fields** -- PCI-compliant card input
+3. **Data Collector** -- device fingerprinting for fraud prevention
+4. **3D Secure** -- cardholder authentication (liability shift)
+
+**Authorization:** Client token required (3D Secure requires a client token).
+
+## Complete Implementation
+
+```javascript
+var braintree = require('braintree-web');
+
+// Step 1: Create client
+braintree.client.create({
+  authorization: CLIENT_TOKEN  // Server-generated client token
+}).then(function (clientInstance) {
+
+  // Step 2: Create components in parallel
+  return Promise.all([
+    braintree.hostedFields.create({
+      client: clientInstance,
+      fields: {
+        number:         { selector: '#card-number', placeholder: '4111 1111 1111 1111' },
+        cvv:            { selector: '#cvv', placeholder: '123' },
+        expirationDate: { selector: '#expiration', placeholder: 'MM/YY' }
+      },
+      styles: {
+        'input':    { 'font-size': '16px' },
+        '.invalid': { 'color': 'red' }
+      }
+    }),
+    braintree.dataCollector.create({
+      client: clientInstance
+    }),
+    braintree.threeDSecure.create({
+      client: clientInstance,
+      version: '2'
+    })
+  ]);
+
+}).then(function (instances) {
+  var hostedFieldsInstance = instances[0];
+  var dataCollectorInstance = instances[1];
+  var threeDSecureInstance = instances[2];
+
+  // Step 3: Register 3DS lookup handler
+  threeDSecureInstance.on('lookup-complete', function (data, next) {
+    // Optionally inspect data.requiresUserAuthentication
+    // Call next() to proceed (shows challenge if needed)
+    next();
+  });
+
+  // Step 4: Enable/disable submit based on validity
+  hostedFieldsInstance.on('validityChange', function (event) {
+    var allValid = Object.keys(event.fields).every(function (key) {
+      return event.fields[key].isValid;
+    });
+    document.getElementById('submit').disabled = !allValid;
+  });
+
+  // Step 5: Handle form submission
+  document.getElementById('submit').addEventListener('click', function () {
+
+    // 5a: Tokenize card
+    hostedFieldsInstance.tokenize().then(function (tokenizePayload) {
+
+      // 5b: Verify with 3DS
+      return threeDSecureInstance.verifyCard({
+        nonce: tokenizePayload.nonce,
+        bin: tokenizePayload.details.bin,
+        amount: document.getElementById('amount').value,
+        email: document.getElementById('email').value,
+        billingAddress: {
+          givenName: 'John',
+          surname: 'Doe',
+          streetAddress: '123 Main St',
+          locality: 'Chicago',
+          region: 'IL',
+          postalCode: '60606',
+          countryCodeAlpha2: 'US'
+        }
+      });
+
+    }).then(function (verifyPayload) {
+
+      // 5c: Send to server with device data
+      return fetch('/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nonce: verifyPayload.nonce,           // NEW nonce from 3DS
+          deviceData: dataCollectorInstance.deviceData,  // Fraud data string
+          liabilityShifted: verifyPayload.threeDSecureInfo.liabilityShifted
+        })
+      });
+
+    }).catch(function (err) {
+      handleError(err);
+    });
+  });
+});
+
+function handleError(err) {
+  switch (err.code) {
+    // Tokenization errors
+    case 'HOSTED_FIELDS_FIELDS_EMPTY':
+      alert('Please enter your card information.');
+      break;
+    case 'HOSTED_FIELDS_FIELDS_INVALID':
+      alert('Some card fields are invalid. Please check and try again.');
+      break;
+
+    // 3DS errors
+    case 'THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR':
+      alert('Card not found. Please re-enter your card.');
+      break;
+    case 'THREEDS_CARDINAL_SDK_CANCELED':
+      alert('Authentication cancelled. Please try again.');
+      break;
+
+    // Network errors (all components)
+    case 'HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR':
+    case 'CLIENT_GATEWAY_NETWORK':
+    case 'CLIENT_REQUEST_TIMEOUT':
+      alert('Network error. Please check your connection and try again.');
+      break;
+
+    default:
+      console.error('Payment error:', err);
+      alert('An error occurred. Please try again.');
+  }
+}
+```
+
+## Error Handling Strategy
+
+| Stage | Possible Errors | Recovery |
+|-------|----------------|----------|
+| Client creation | `CLIENT_INVALID_AUTHORIZATION`, `CLIENT_GATEWAY_NETWORK` | Refresh client token, retry |
+| Hosted Fields creation | `HOSTED_FIELDS_TIMEOUT`, `HOSTED_FIELDS_INVALID_FIELD_SELECTOR` | Check DOM, CSP, network |
+| 3DS creation | `THREEDS_NOT_ENABLED`, `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY` | Enable 3DS, use client token |
+| Tokenization | `HOSTED_FIELDS_FIELDS_EMPTY`, `HOSTED_FIELDS_FIELDS_INVALID` | Prompt user to fix input |
+| 3DS verification | `THREEDS_CARDINAL_SDK_CANCELED`, `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | Allow retry, use fresh nonce |
+
+## Key Points
+
+- **Nonce lifecycle:** Original nonce from `tokenize()` is consumed by 3DS lookup. Always use the nonce from `verifyCard()` result.
+- **Device data:** `dataCollectorInstance.deviceData` is a JSON string. Send it as-is to your server.
+- **Liability shift:** Check `verifyPayload.threeDSecureInfo.liabilityShifted`. Decide server-side whether to proceed if false.
+- **Billing address:** Providing complete billing info improves frictionless authentication rates.
+
+## Teardown
+
+```javascript
+Promise.all([
+  hostedFieldsInstance.teardown(),
+  dataCollectorInstance.teardown(),
+  threeDSecureInstance.teardown()
+]).then(function () {
+  // All cleaned up
+});
+```

--- a/.well-known/agent-skills/skills/braintree-card-payment-full.md
+++ b/.well-known/agent-skills/skills/braintree-card-payment-full.md
@@ -19,139 +19,142 @@ This skill covers the most common production integration: collect card data, gat
 ## Complete Implementation
 
 ```javascript
-var braintree = require('braintree-web');
+var braintree = require("braintree-web");
 
 // Step 1: Create client
-braintree.client.create({
-  authorization: CLIENT_TOKEN  // Server-generated client token
-}).then(function (clientInstance) {
+braintree.client
+  .create({
+    authorization: CLIENT_TOKEN, // Server-generated client token
+  })
+  .then(function (clientInstance) {
+    // Step 2: Create components in parallel
+    return Promise.all([
+      braintree.hostedFields.create({
+        client: clientInstance,
+        fields: {
+          number: {
+            selector: "#card-number",
+            placeholder: "4111 1111 1111 1111",
+          },
+          cvv: { selector: "#cvv", placeholder: "123" },
+          expirationDate: { selector: "#expiration", placeholder: "MM/YY" },
+        },
+        styles: {
+          input: { "font-size": "16px" },
+          ".invalid": { color: "red" },
+        },
+      }),
+      braintree.dataCollector.create({
+        client: clientInstance,
+      }),
+      braintree.threeDSecure.create({
+        client: clientInstance,
+        version: "2",
+      }),
+    ]);
+  })
+  .then(function (instances) {
+    var hostedFieldsInstance = instances[0];
+    var dataCollectorInstance = instances[1];
+    var threeDSecureInstance = instances[2];
 
-  // Step 2: Create components in parallel
-  return Promise.all([
-    braintree.hostedFields.create({
-      client: clientInstance,
-      fields: {
-        number:         { selector: '#card-number', placeholder: '4111 1111 1111 1111' },
-        cvv:            { selector: '#cvv', placeholder: '123' },
-        expirationDate: { selector: '#expiration', placeholder: 'MM/YY' }
-      },
-      styles: {
-        'input':    { 'font-size': '16px' },
-        '.invalid': { 'color': 'red' }
-      }
-    }),
-    braintree.dataCollector.create({
-      client: clientInstance
-    }),
-    braintree.threeDSecure.create({
-      client: clientInstance,
-      version: '2'
-    })
-  ]);
-
-}).then(function (instances) {
-  var hostedFieldsInstance = instances[0];
-  var dataCollectorInstance = instances[1];
-  var threeDSecureInstance = instances[2];
-
-  // Step 3: Register 3DS lookup handler
-  threeDSecureInstance.on('lookup-complete', function (data, next) {
-    // Optionally inspect data.requiresUserAuthentication
-    // Call next() to proceed (shows challenge if needed)
-    next();
-  });
-
-  // Step 4: Enable/disable submit based on validity
-  hostedFieldsInstance.on('validityChange', function (event) {
-    var allValid = Object.keys(event.fields).every(function (key) {
-      return event.fields[key].isValid;
+    // Step 3: Register 3DS lookup handler
+    threeDSecureInstance.on("lookup-complete", function (data, next) {
+      // Optionally inspect data.requiresUserAuthentication
+      // Call next() to proceed (shows challenge if needed)
+      next();
     });
-    document.getElementById('submit').disabled = !allValid;
-  });
 
-  // Step 5: Handle form submission
-  document.getElementById('submit').addEventListener('click', function () {
-
-    // 5a: Tokenize card
-    hostedFieldsInstance.tokenize().then(function (tokenizePayload) {
-
-      // 5b: Verify with 3DS
-      return threeDSecureInstance.verifyCard({
-        nonce: tokenizePayload.nonce,
-        bin: tokenizePayload.details.bin,
-        amount: document.getElementById('amount').value,
-        email: document.getElementById('email').value,
-        billingAddress: {
-          givenName: 'John',
-          surname: 'Doe',
-          streetAddress: '123 Main St',
-          locality: 'Chicago',
-          region: 'IL',
-          postalCode: '60606',
-          countryCodeAlpha2: 'US'
-        }
+    // Step 4: Enable/disable submit based on validity
+    hostedFieldsInstance.on("validityChange", function (event) {
+      var allValid = Object.keys(event.fields).every(function (key) {
+        return event.fields[key].isValid;
       });
+      document.getElementById("submit").disabled = !allValid;
+    });
 
-    }).then(function (verifyPayload) {
-
-      // 5c: Send to server with device data
-      return fetch('/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          nonce: verifyPayload.nonce,           // NEW nonce from 3DS
-          deviceData: dataCollectorInstance.deviceData,  // Fraud data string
-          liabilityShifted: verifyPayload.threeDSecureInfo.liabilityShifted
+    // Step 5: Handle form submission
+    document.getElementById("submit").addEventListener("click", function () {
+      // 5a: Tokenize card
+      hostedFieldsInstance
+        .tokenize()
+        .then(function (tokenizePayload) {
+          // 5b: Verify with 3DS
+          return threeDSecureInstance.verifyCard({
+            nonce: tokenizePayload.nonce,
+            bin: tokenizePayload.details.bin,
+            amount: document.getElementById("amount").value,
+            email: document.getElementById("email").value,
+            billingAddress: {
+              givenName: "John",
+              surname: "Doe",
+              streetAddress: "123 Main St",
+              locality: "Chicago",
+              region: "IL",
+              postalCode: "60606",
+              countryCodeAlpha2: "US",
+            },
+          });
         })
-      });
-
-    }).catch(function (err) {
-      handleError(err);
+        .then(function (verifyPayload) {
+          // 5c: Send to server with device data
+          return fetch("/checkout", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              nonce: verifyPayload.nonce, // NEW nonce from 3DS
+              deviceData: dataCollectorInstance.deviceData, // Fraud data string
+              liabilityShifted: verifyPayload.threeDSecureInfo.liabilityShifted,
+            }),
+          });
+        })
+        .catch(function (err) {
+          handleError(err);
+        });
     });
   });
-});
 
 function handleError(err) {
   switch (err.code) {
     // Tokenization errors
-    case 'HOSTED_FIELDS_FIELDS_EMPTY':
-      alert('Please enter your card information.');
+    case "HOSTED_FIELDS_FIELDS_EMPTY":
+      alert("Please enter your card information.");
       break;
-    case 'HOSTED_FIELDS_FIELDS_INVALID':
-      alert('Some card fields are invalid. Please check and try again.');
+    case "HOSTED_FIELDS_FIELDS_INVALID":
+      alert("Some card fields are invalid. Please check and try again.");
       break;
 
     // 3DS errors
-    case 'THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR':
-      alert('Card not found. Please re-enter your card.');
+    case "THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR":
+      alert("Card not found. Please re-enter your card.");
       break;
-    case 'THREEDS_CARDINAL_SDK_CANCELED':
-      alert('Authentication cancelled. Please try again.');
+    case "THREEDS_CARDINAL_SDK_CANCELED":
+      alert("Authentication cancelled. Please try again.");
       break;
 
     // Network errors (all components)
-    case 'HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR':
-    case 'CLIENT_GATEWAY_NETWORK':
-    case 'CLIENT_REQUEST_TIMEOUT':
-      alert('Network error. Please check your connection and try again.');
+    case "HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR":
+    case "CLIENT_GATEWAY_NETWORK":
+    case "CLIENT_REQUEST_TIMEOUT":
+      alert("Network error. Please check your connection and try again.");
       break;
 
     default:
-      console.error('Payment error:', err);
-      alert('An error occurred. Please try again.');
+      console.error("Payment error:", err);
+      alert("An error occurred. Please try again.");
   }
 }
 ```
 
 ## Error Handling Strategy
 
-| Stage | Possible Errors | Recovery |
-|-------|----------------|----------|
-| Client creation | `CLIENT_INVALID_AUTHORIZATION`, `CLIENT_GATEWAY_NETWORK` | Refresh client token, retry |
-| Hosted Fields creation | `HOSTED_FIELDS_TIMEOUT`, `HOSTED_FIELDS_INVALID_FIELD_SELECTOR` | Check DOM, CSP, network |
-| 3DS creation | `THREEDS_NOT_ENABLED`, `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY` | Enable 3DS, use client token |
-| Tokenization | `HOSTED_FIELDS_FIELDS_EMPTY`, `HOSTED_FIELDS_FIELDS_INVALID` | Prompt user to fix input |
-| 3DS verification | `THREEDS_CARDINAL_SDK_CANCELED`, `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | Allow retry, use fresh nonce |
+| Stage                  | Possible Errors                                                                  | Recovery                     |
+| ---------------------- | -------------------------------------------------------------------------------- | ---------------------------- |
+| Client creation        | `CLIENT_INVALID_AUTHORIZATION`, `CLIENT_GATEWAY_NETWORK`                         | Refresh client token, retry  |
+| Hosted Fields creation | `HOSTED_FIELDS_TIMEOUT`, `HOSTED_FIELDS_INVALID_FIELD_SELECTOR`                  | Check DOM, CSP, network      |
+| 3DS creation           | `THREEDS_NOT_ENABLED`, `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY`                    | Enable 3DS, use client token |
+| Tokenization           | `HOSTED_FIELDS_FIELDS_EMPTY`, `HOSTED_FIELDS_FIELDS_INVALID`                     | Prompt user to fix input     |
+| 3DS verification       | `THREEDS_CARDINAL_SDK_CANCELED`, `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | Allow retry, use fresh nonce |
 
 ## Key Points
 
@@ -166,7 +169,7 @@ function handleError(err) {
 Promise.all([
   hostedFieldsInstance.teardown(),
   dataCollectorInstance.teardown(),
-  threeDSecureInstance.teardown()
+  threeDSecureInstance.teardown(),
 ]).then(function () {
   // All cleaned up
 });

--- a/.well-known/agent-skills/skills/braintree-card-payments.md
+++ b/.well-known/agent-skills/skills/braintree-card-payments.md
@@ -1,0 +1,149 @@
+---
+name: braintree-card-payments
+description: Hosted Fields PCI-compliant card collection via iframes - field configuration, styling, events, and tokenization
+---
+
+# Hosted Fields - Card Payment Integration
+
+## Architecture
+
+Each card input field runs in its own sandboxed iframe. Card data never touches your DOM or JavaScript, ensuring PCI compliance.
+
+## Setup
+
+```javascript
+braintree.hostedFields.create({
+  client: clientInstance,  // or authorization: 'token'
+  fields: {
+    number:         { selector: '#card-number', placeholder: '4111 1111 1111 1111' },
+    cvv:            { selector: '#cvv', placeholder: '123' },
+    expirationDate: { selector: '#expiration', placeholder: 'MM/YY' }
+  },
+  styles: {
+    'input':    { 'font-size': '16px', 'color': '#333' },
+    ':focus':   { 'color': '#000' },
+    '.valid':   { 'color': 'green' },
+    '.invalid': { 'color': 'red' }
+  }
+}, function (err, hostedFieldsInstance) {
+  if (err) { console.error(err); return; }
+  // Ready
+});
+```
+
+## Available Fields
+
+| Field Key | Purpose | Notes |
+|-----------|---------|-------|
+| `number` | Card number | Auto-detects card type, formats with spaces |
+| `cvv` | Security code | 3-4 digits depending on card type |
+| `expirationDate` | Combined MM/YY | Auto-inserts slash |
+| `expirationMonth` | Month only | Use with `expirationYear` |
+| `expirationYear` | Year only | Use with `expirationMonth` |
+| `postalCode` | ZIP/postal code | Configurable `maxlength` (default 10) |
+| `cardholderName` | Name on card | Optional text field |
+
+**Field options:** `selector` (required), `placeholder`, `type` (such as `'password'` for CVV), `prefill`, `maxlength`, `minlength`, `formatInput` (boolean), `maskInput` (object), `select` (for dropdowns on month/year).
+
+## Events
+
+```javascript
+hostedFieldsInstance.on('focus', function (event) {
+  // event.emittedBy: 'number', 'cvv', etc.
+  // event.fields: state of all fields
+});
+
+hostedFieldsInstance.on('blur', function (event) { /* ... */ });
+
+hostedFieldsInstance.on('validityChange', function (event) {
+  // event.fields.number.isValid, .isPotentiallyValid, .isEmpty
+  var allValid = Object.keys(event.fields).every(function (key) {
+    return event.fields[key].isValid;
+  });
+  submitButton.disabled = !allValid;
+});
+
+hostedFieldsInstance.on('cardTypeChange', function (event) {
+  // event.cards: array of possible card types
+  // event.cards[0].type: 'visa', 'master-card', 'american-express', etc.
+});
+
+hostedFieldsInstance.on('binAvailable', function (event) {
+  // event.bin: first 6-8 digits for BIN lookup
+});
+
+hostedFieldsInstance.on('inputSubmitRequest', function () {
+  // User pressed Enter in a field -- trigger form submission
+  hostedFieldsInstance.tokenize(/* ... */);
+});
+```
+
+## Tokenization
+
+```javascript
+hostedFieldsInstance.tokenize({
+  vault: false,                    // true to store in vault (requires client token)
+  cardholderName: 'John Doe',     // if not using cardholderName field
+  billingAddress: {
+    postalCode: '12345',           // if not using postalCode field
+    streetAddress: '123 Main St'
+  }
+}, function (err, payload) {
+  if (err) {
+    // Handle specific errors
+    if (err.code === 'HOSTED_FIELDS_FIELDS_EMPTY') { /* all empty */ }
+    if (err.code === 'HOSTED_FIELDS_FIELDS_INVALID') { /* validation failed */ }
+    return;
+  }
+  // payload.nonce -- send to server
+  // payload.details.bin -- card BIN
+  // payload.details.cardType -- 'Visa', 'Mastercard', and so on
+  // payload.details.lastFour -- '1111'
+  // payload.details.lastTwo -- '11'
+});
+```
+
+## Field State
+
+```javascript
+var state = hostedFieldsInstance.getState();
+// state.cards: detected card types
+// state.fields.number: { isEmpty, isValid, isPotentiallyValid, isFocused }
+// state.fields.cvv: { ... }
+```
+
+## Additional Methods
+
+```javascript
+hostedFieldsInstance.clear('number');                          // Clear a field
+hostedFieldsInstance.focus('number');                          // Focus a field
+hostedFieldsInstance.setPlaceholder('number', 'Card number'); // Change placeholder
+hostedFieldsInstance.setAttribute({
+  field: 'number',
+  attribute: 'aria-label',
+  value: 'Credit card number'
+});
+hostedFieldsInstance.removeAttribute({ field: 'number', attribute: 'aria-label' });
+hostedFieldsInstance.addClass('number', 'my-class');
+hostedFieldsInstance.removeClass('number', 'my-class');
+```
+
+## Common Errors
+
+| Code | Type | Cause | Fix |
+|------|------|-------|-----|
+| `HOSTED_FIELDS_TIMEOUT` | UNKNOWN | Setup took >60s | Check network, CSP policy, iframe URLs |
+| `HOSTED_FIELDS_INVALID_FIELD_KEY` | MERCHANT | Unknown field name | Use valid field keys listed above |
+| `HOSTED_FIELDS_INVALID_FIELD_SELECTOR` | MERCHANT | Selector not found in DOM | Ensure container element exists before create |
+| `HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME` | MERCHANT | Container already has HF iframe | Don't call create twice on same containers |
+| `HOSTED_FIELDS_FIELDS_EMPTY` | CUSTOMER | All fields empty on tokenize | Prompt user to enter card info |
+| `HOSTED_FIELDS_FIELDS_INVALID` | CUSTOMER | Validation failed on tokenize | Show validation errors per field |
+| `HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR` | NETWORK | Gateway unreachable | Retry with backoff |
+| `HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE` | CUSTOMER | Card already in vault | Inform user, use existing payment method |
+| `HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED` | CUSTOMER | CVV check failed | Ask user to re-enter CVV |
+
+## CSP Requirements
+
+Allow in Content-Security-Policy:
+- `frame-src`: `https://assets.braintreegateway.com`
+- `script-src`: `https://js.braintreegateway.com`

--- a/.well-known/agent-skills/skills/braintree-card-payments.md
+++ b/.well-known/agent-skills/skills/braintree-card-payments.md
@@ -12,50 +12,58 @@ Each card input field runs in its own sandboxed iframe. Card data never touches 
 ## Setup
 
 ```javascript
-braintree.hostedFields.create({
-  client: clientInstance,  // or authorization: 'token'
-  fields: {
-    number:         { selector: '#card-number', placeholder: '4111 1111 1111 1111' },
-    cvv:            { selector: '#cvv', placeholder: '123' },
-    expirationDate: { selector: '#expiration', placeholder: 'MM/YY' }
+braintree.hostedFields.create(
+  {
+    client: clientInstance, // or authorization: 'token'
+    fields: {
+      number: { selector: "#card-number", placeholder: "4111 1111 1111 1111" },
+      cvv: { selector: "#cvv", placeholder: "123" },
+      expirationDate: { selector: "#expiration", placeholder: "MM/YY" },
+    },
+    styles: {
+      input: { "font-size": "16px", color: "#333" },
+      ":focus": { color: "#000" },
+      ".valid": { color: "green" },
+      ".invalid": { color: "red" },
+    },
   },
-  styles: {
-    'input':    { 'font-size': '16px', 'color': '#333' },
-    ':focus':   { 'color': '#000' },
-    '.valid':   { 'color': 'green' },
-    '.invalid': { 'color': 'red' }
+  function (err, hostedFieldsInstance) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    // Ready
   }
-}, function (err, hostedFieldsInstance) {
-  if (err) { console.error(err); return; }
-  // Ready
-});
+);
 ```
 
 ## Available Fields
 
-| Field Key | Purpose | Notes |
-|-----------|---------|-------|
-| `number` | Card number | Auto-detects card type, formats with spaces |
-| `cvv` | Security code | 3-4 digits depending on card type |
-| `expirationDate` | Combined MM/YY | Auto-inserts slash |
-| `expirationMonth` | Month only | Use with `expirationYear` |
-| `expirationYear` | Year only | Use with `expirationMonth` |
-| `postalCode` | ZIP/postal code | Configurable `maxlength` (default 10) |
-| `cardholderName` | Name on card | Optional text field |
+| Field Key         | Purpose         | Notes                                       |
+| ----------------- | --------------- | ------------------------------------------- |
+| `number`          | Card number     | Auto-detects card type, formats with spaces |
+| `cvv`             | Security code   | 3-4 digits depending on card type           |
+| `expirationDate`  | Combined MM/YY  | Auto-inserts slash                          |
+| `expirationMonth` | Month only      | Use with `expirationYear`                   |
+| `expirationYear`  | Year only       | Use with `expirationMonth`                  |
+| `postalCode`      | ZIP/postal code | Configurable `maxlength` (default 10)       |
+| `cardholderName`  | Name on card    | Optional text field                         |
 
 **Field options:** `selector` (required), `placeholder`, `type` (such as `'password'` for CVV), `prefill`, `maxlength`, `minlength`, `formatInput` (boolean), `maskInput` (object), `select` (for dropdowns on month/year).
 
 ## Events
 
 ```javascript
-hostedFieldsInstance.on('focus', function (event) {
+hostedFieldsInstance.on("focus", function (event) {
   // event.emittedBy: 'number', 'cvv', etc.
   // event.fields: state of all fields
 });
 
-hostedFieldsInstance.on('blur', function (event) { /* ... */ });
+hostedFieldsInstance.on("blur", function (event) {
+  /* ... */
+});
 
-hostedFieldsInstance.on('validityChange', function (event) {
+hostedFieldsInstance.on("validityChange", function (event) {
   // event.fields.number.isValid, .isPotentiallyValid, .isEmpty
   var allValid = Object.keys(event.fields).every(function (key) {
     return event.fields[key].isValid;
@@ -63,16 +71,16 @@ hostedFieldsInstance.on('validityChange', function (event) {
   submitButton.disabled = !allValid;
 });
 
-hostedFieldsInstance.on('cardTypeChange', function (event) {
+hostedFieldsInstance.on("cardTypeChange", function (event) {
   // event.cards: array of possible card types
   // event.cards[0].type: 'visa', 'master-card', 'american-express', etc.
 });
 
-hostedFieldsInstance.on('binAvailable', function (event) {
+hostedFieldsInstance.on("binAvailable", function (event) {
   // event.bin: first 6-8 digits for BIN lookup
 });
 
-hostedFieldsInstance.on('inputSubmitRequest', function () {
+hostedFieldsInstance.on("inputSubmitRequest", function () {
   // User pressed Enter in a field -- trigger form submission
   hostedFieldsInstance.tokenize(/* ... */);
 });
@@ -81,26 +89,33 @@ hostedFieldsInstance.on('inputSubmitRequest', function () {
 ## Tokenization
 
 ```javascript
-hostedFieldsInstance.tokenize({
-  vault: false,                    // true to store in vault (requires client token)
-  cardholderName: 'John Doe',     // if not using cardholderName field
-  billingAddress: {
-    postalCode: '12345',           // if not using postalCode field
-    streetAddress: '123 Main St'
+hostedFieldsInstance.tokenize(
+  {
+    vault: false, // true to store in vault (requires client token)
+    cardholderName: "John Doe", // if not using cardholderName field
+    billingAddress: {
+      postalCode: "12345", // if not using postalCode field
+      streetAddress: "123 Main St",
+    },
+  },
+  function (err, payload) {
+    if (err) {
+      // Handle specific errors
+      if (err.code === "HOSTED_FIELDS_FIELDS_EMPTY") {
+        /* all empty */
+      }
+      if (err.code === "HOSTED_FIELDS_FIELDS_INVALID") {
+        /* validation failed */
+      }
+      return;
+    }
+    // payload.nonce -- send to server
+    // payload.details.bin -- card BIN
+    // payload.details.cardType -- 'Visa', 'Mastercard', and so on
+    // payload.details.lastFour -- '1111'
+    // payload.details.lastTwo -- '11'
   }
-}, function (err, payload) {
-  if (err) {
-    // Handle specific errors
-    if (err.code === 'HOSTED_FIELDS_FIELDS_EMPTY') { /* all empty */ }
-    if (err.code === 'HOSTED_FIELDS_FIELDS_INVALID') { /* validation failed */ }
-    return;
-  }
-  // payload.nonce -- send to server
-  // payload.details.bin -- card BIN
-  // payload.details.cardType -- 'Visa', 'Mastercard', and so on
-  // payload.details.lastFour -- '1111'
-  // payload.details.lastTwo -- '11'
-});
+);
 ```
 
 ## Field State
@@ -115,35 +130,53 @@ var state = hostedFieldsInstance.getState();
 ## Additional Methods
 
 ```javascript
-hostedFieldsInstance.clear('number');                          // Clear a field
-hostedFieldsInstance.focus('number');                          // Focus a field
-hostedFieldsInstance.setPlaceholder('number', 'Card number'); // Change placeholder
+hostedFieldsInstance.clear("number"); // Clear a field
+hostedFieldsInstance.focus("number"); // Focus a field
+hostedFieldsInstance.setPlaceholder("number", "Card number"); // Change placeholder
 hostedFieldsInstance.setAttribute({
-  field: 'number',
-  attribute: 'aria-label',
-  value: 'Credit card number'
+  field: "number",
+  attribute: "aria-label",
+  value: "Credit card number",
 });
-hostedFieldsInstance.removeAttribute({ field: 'number', attribute: 'aria-label' });
-hostedFieldsInstance.addClass('number', 'my-class');
-hostedFieldsInstance.removeClass('number', 'my-class');
+hostedFieldsInstance.removeAttribute({
+  field: "number",
+  attribute: "aria-label",
+});
+hostedFieldsInstance.addClass("number", "my-class");
+hostedFieldsInstance.removeClass("number", "my-class");
 ```
 
 ## Common Errors
 
-| Code | Type | Cause | Fix |
-|------|------|-------|-----|
-| `HOSTED_FIELDS_TIMEOUT` | UNKNOWN | Setup took >60s | Check network, CSP policy, iframe URLs |
-| `HOSTED_FIELDS_INVALID_FIELD_KEY` | MERCHANT | Unknown field name | Use valid field keys listed above |
-| `HOSTED_FIELDS_INVALID_FIELD_SELECTOR` | MERCHANT | Selector not found in DOM | Ensure container element exists before create |
-| `HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME` | MERCHANT | Container already has HF iframe | Don't call create twice on same containers |
-| `HOSTED_FIELDS_FIELDS_EMPTY` | CUSTOMER | All fields empty on tokenize | Prompt user to enter card info |
-| `HOSTED_FIELDS_FIELDS_INVALID` | CUSTOMER | Validation failed on tokenize | Show validation errors per field |
-| `HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR` | NETWORK | Gateway unreachable | Retry with backoff |
-| `HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE` | CUSTOMER | Card already in vault | Inform user, use existing payment method |
-| `HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED` | CUSTOMER | CVV check failed | Ask user to re-enter CVV |
+| Code                                                 | Type     | Cause                           | Fix                                           |
+| ---------------------------------------------------- | -------- | ------------------------------- | --------------------------------------------- |
+| `HOSTED_FIELDS_TIMEOUT`                              | UNKNOWN  | Setup took >60s                 | Check network, CSP policy, iframe URLs        |
+| `HOSTED_FIELDS_INVALID_FIELD_KEY`                    | MERCHANT | Unknown field name              | Use valid field keys listed above             |
+| `HOSTED_FIELDS_INVALID_FIELD_SELECTOR`               | MERCHANT | Selector not found in DOM       | Ensure container element exists before create |
+| `HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME`               | MERCHANT | Container already has HF iframe | Don't call create twice on same containers    |
+| `HOSTED_FIELDS_FIELDS_EMPTY`                         | CUSTOMER | All fields empty on tokenize    | Prompt user to enter card info                |
+| `HOSTED_FIELDS_FIELDS_INVALID`                       | CUSTOMER | Validation failed on tokenize   | Show validation errors per field              |
+| `HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR`           | NETWORK  | Gateway unreachable             | Retry with backoff                            |
+| `HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE`       | CUSTOMER | Card already in vault           | Inform user, use existing payment method      |
+| `HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED` | CUSTOMER | CVV check failed                | Ask user to re-enter CVV                      |
+
+## Teardown
+
+In single-page applications (SPAs), always tear down Hosted Fields before re-creating or when the payment form is removed from the DOM. Failing to teardown causes orphaned iframes, duplicate event handlers, and `HOSTED_FIELDS_TIMEOUT` errors on subsequent `create()` calls.
+
+```javascript
+hostedFieldsInstance.teardown().then(function () {
+  // Safe to create new instance or remove form from DOM
+});
+```
+
+**SPA pattern:** Track the `create()` promise. If the user navigates away before it resolves, call `teardown()` on the instance once it becomes available.
 
 ## CSP Requirements
 
 Allow in Content-Security-Policy:
+
 - `frame-src`: `https://assets.braintreegateway.com`
 - `script-src`: `https://js.braintreegateway.com`
+- `style-src`: `'unsafe-inline'` (required -- Hosted Fields renders iframe content using inline styles)
+- `connect-src`: `https://*.braintreegateway.com`, `https://*.braintree-api.com`

--- a/.well-known/agent-skills/skills/braintree-error-resolution.md
+++ b/.well-known/agent-skills/skills/braintree-error-resolution.md
@@ -9,118 +9,118 @@ description: Complete error code reference and resolution guide for all Braintre
 
 All errors are `BraintreeError` instances. Check `err.type` for category, `err.code` for specific error:
 
-| Type | Meaning | Action |
-|------|---------|--------|
-| `CUSTOMER` | End-user input/action problem | Show message to user, allow retry |
+| Type       | Meaning                         | Action                                     |
+| ---------- | ------------------------------- | ------------------------------------------ |
+| `CUSTOMER` | End-user input/action problem   | Show message to user, allow retry          |
 | `MERCHANT` | Integration/configuration error | Fix integration code or Braintree settings |
-| `NETWORK` | Connectivity/timeout issue | Retry with exponential backoff |
-| `INTERNAL` | SDK bug | Report to Braintree support |
-| `UNKNOWN` | Indeterminate cause | Check `err.details`, investigate logs |
+| `NETWORK`  | Connectivity/timeout issue      | Retry with exponential backoff             |
+| `INTERNAL` | SDK bug                         | Report to Braintree support                |
+| `UNKNOWN`  | Indeterminate cause             | Check `err.details`, investigate logs      |
 
 ## Shared Errors (All Components)
 
-| Code | Type | Resolution |
-|------|------|-----------|
-| `INCOMPATIBLE_VERSIONS` | MERCHANT | All SDK components must use the same version. Check CDN script tags or npm imports. |
-| `INSTANTIATION_OPTION_REQUIRED` | MERCHANT | Missing `client` or `authorization` in create options. |
-| `CLIENT_SCRIPT_FAILED_TO_LOAD` | NETWORK | Network error loading client script. Check internet, CSP policy, CDN availability. |
-| `METHOD_CALLED_AFTER_TEARDOWN` | MERCHANT | Instance was torn down. Create a new instance before calling methods. |
-| `INSTANTIATION_OPTION_INVALID` | MERCHANT | Bad option value passed to create. Check the option types and formats. |
+| Code                            | Type     | Resolution                                                                          |
+| ------------------------------- | -------- | ----------------------------------------------------------------------------------- |
+| `INCOMPATIBLE_VERSIONS`         | MERCHANT | All SDK components must use the same version. Check CDN script tags or npm imports. |
+| `INSTANTIATION_OPTION_REQUIRED` | MERCHANT | Missing `client` or `authorization` in create options.                              |
+| `CLIENT_SCRIPT_FAILED_TO_LOAD`  | NETWORK  | Network error loading client script. Check internet, CSP policy, CDN availability.  |
+| `METHOD_CALLED_AFTER_TEARDOWN`  | MERCHANT | Instance was torn down. Create a new instance before calling methods.               |
+| `INSTANTIATION_OPTION_INVALID`  | MERCHANT | Bad option value passed to create. Check the option types and formats.              |
 
 ## Client Errors
 
-| Code | Type | Resolution |
-|------|------|-----------|
-| `CLIENT_INVALID_AUTHORIZATION` | MERCHANT | Authorization string cannot be parsed. Verify it is a valid tokenization key (`sandbox_xxx_yyy`) or base64-encoded client token. |
-| `CLIENT_AUTHORIZATION_INVALID` | MERCHANT | Token expired or deleted. **Client tokens expire ~24h.** Generate a fresh one from your server. Tokenization keys: check they are not deactivated in control panel. |
-| `CLIENT_GATEWAY_NETWORK` | NETWORK | Cannot reach Braintree gateway. Check internet, firewall, DNS. Retry with backoff. |
-| `CLIENT_REQUEST_TIMEOUT` | NETWORK | Request exceeded 60-second timeout. Check network speed. Retry. |
-| `CLIENT_REQUEST_ERROR` | NETWORK | Server returned HTTP 400+. Check `err.details` for server error message. |
-| `CLIENT_GRAPHQL_REQUEST_ERROR` | NETWORK | GraphQL error. Check `err.details` for specific GraphQL errors. |
-| `CLIENT_RATE_LIMITED` | MERCHANT | HTTP 429. Too many requests. Implement exponential backoff. |
-| `CLIENT_AUTHORIZATION_INSUFFICIENT` | MERCHANT | Authorization lacks permissions. Use client token instead of tokenization key for features requiring elevated permissions (3DS, vaulting). |
+| Code                                | Type     | Resolution                                                                                                                                                          |
+| ----------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_INVALID_AUTHORIZATION`      | MERCHANT | Authorization string cannot be parsed. Verify it is a valid tokenization key (`sandbox_xxx_yyy`) or base64-encoded client token.                                    |
+| `CLIENT_AUTHORIZATION_INVALID`      | MERCHANT | Token expired or deleted. **Client tokens expire ~24h.** Generate a fresh one from your server. Tokenization keys: check they are not deactivated in control panel. |
+| `CLIENT_GATEWAY_NETWORK`            | NETWORK  | Cannot reach Braintree gateway. Check internet, firewall, DNS. Retry with backoff.                                                                                  |
+| `CLIENT_REQUEST_TIMEOUT`            | NETWORK  | Request exceeded 60-second timeout. Check network speed. Retry.                                                                                                     |
+| `CLIENT_REQUEST_ERROR`              | NETWORK  | Server returned HTTP 400+. Check `err.details` for server error message.                                                                                            |
+| `CLIENT_GRAPHQL_REQUEST_ERROR`      | NETWORK  | GraphQL error. Check `err.details` for specific GraphQL errors.                                                                                                     |
+| `CLIENT_RATE_LIMITED`               | MERCHANT | HTTP 429. Too many requests. Implement exponential backoff.                                                                                                         |
+| `CLIENT_AUTHORIZATION_INSUFFICIENT` | MERCHANT | Authorization lacks permissions. Use client token instead of tokenization key for features requiring elevated permissions (3DS, vaulting).                          |
 
 ## Hosted Fields Errors
 
-| Code | Type | Resolution |
-|------|------|-----------|
-| `HOSTED_FIELDS_TIMEOUT` | UNKNOWN | Iframe setup took >60s. Check CSP allows `assets.braintreegateway.com` in `frame-src`. Verify network. |
-| `HOSTED_FIELDS_INVALID_FIELD_KEY` | MERCHANT | Field name not recognized. Valid keys: `number`, `cvv`, `expirationDate`, `expirationMonth`, `expirationYear`, `postalCode`, `cardholderName`. |
-| `HOSTED_FIELDS_INVALID_FIELD_SELECTOR` | MERCHANT | CSS selector not found in DOM. Ensure container element exists before calling create. |
-| `HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME` | MERCHANT | Container already has a Hosted Fields iframe. Don't call create twice on same elements. Teardown first. |
-| `HOSTED_FIELDS_FIELDS_EMPTY` | CUSTOMER | All fields empty when tokenize called. Prompt user to enter card data. |
-| `HOSTED_FIELDS_FIELDS_INVALID` | CUSTOMER | One or more fields failed validation. Check `getState()` for which fields are invalid. |
-| `HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR` | NETWORK | Gateway unreachable during tokenization. Retry. |
-| `HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE` | CUSTOMER | Card already exists in vault. Use existing payment method or allow user to override. |
-| `HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED` | CUSTOMER | CVV check failed. Ask user to re-enter CVV. |
+| Code                                                 | Type     | Resolution                                                                                                                                     |
+| ---------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HOSTED_FIELDS_TIMEOUT`                              | UNKNOWN  | Iframe setup took >60s. Check CSP allows `assets.braintreegateway.com` in `frame-src`. Verify network.                                         |
+| `HOSTED_FIELDS_INVALID_FIELD_KEY`                    | MERCHANT | Field name not recognized. Valid keys: `number`, `cvv`, `expirationDate`, `expirationMonth`, `expirationYear`, `postalCode`, `cardholderName`. |
+| `HOSTED_FIELDS_INVALID_FIELD_SELECTOR`               | MERCHANT | CSS selector not found in DOM. Ensure container element exists before calling create.                                                          |
+| `HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME`               | MERCHANT | Container already has a Hosted Fields iframe. Don't call create twice on same elements. Teardown first.                                        |
+| `HOSTED_FIELDS_FIELDS_EMPTY`                         | CUSTOMER | All fields empty when tokenize called. Prompt user to enter card data.                                                                         |
+| `HOSTED_FIELDS_FIELDS_INVALID`                       | CUSTOMER | One or more fields failed validation. Check `getState()` for which fields are invalid.                                                         |
+| `HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR`           | NETWORK  | Gateway unreachable during tokenization. Retry.                                                                                                |
+| `HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE`       | CUSTOMER | Card already exists in vault. Use existing payment method or allow user to override.                                                           |
+| `HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED` | CUSTOMER | CVV check failed. Ask user to re-enter CVV.                                                                                                    |
 
 ## 3D Secure Errors
 
-| Code | Type | Resolution |
-|------|------|-----------|
-| `THREEDS_NOT_ENABLED` | MERCHANT | Enable 3DS in Braintree control panel. Contact support if needed. |
-| `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY` | MERCHANT | 3DS requires a client token. Generate one from your server. |
-| `THREEDS_HTTPS_REQUIRED` | MERCHANT | Serve page over HTTPS. |
-| `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED` | NETWORK | CSP must allow `script-src: songbird.cardinalcommerce.com`. Check for ad blockers. |
-| `THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT` | UNKNOWN | Cardinal took >60s to initialize. Check network. |
-| `THREEDS_AUTHENTICATION_IN_PROGRESS` | MERCHANT | `verifyCard` called while another is running. Wait for completion. |
-| `THREEDS_MISSING_VERIFY_CARD_OPTION` | MERCHANT | Provide `nonce`, `bin`, and `amount` to verifyCard. |
-| `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | MERCHANT | Nonce invalid or already consumed. Use a fresh nonce from tokenization. |
-| `THREEDS_CARDINAL_SDK_CANCELED` | CUSTOMER | User closed the challenge modal. Allow retry. |
+| Code                                            | Type     | Resolution                                                                         |
+| ----------------------------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `THREEDS_NOT_ENABLED`                           | MERCHANT | Enable 3DS in Braintree control panel. Contact support if needed.                  |
+| `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY`          | MERCHANT | 3DS requires a client token. Generate one from your server.                        |
+| `THREEDS_HTTPS_REQUIRED`                        | MERCHANT | Serve page over HTTPS.                                                             |
+| `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED`       | NETWORK  | CSP must allow `script-src: songbird.cardinalcommerce.com`. Check for ad blockers. |
+| `THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT`           | UNKNOWN  | Cardinal took >60s to initialize. Check network.                                   |
+| `THREEDS_AUTHENTICATION_IN_PROGRESS`            | MERCHANT | `verifyCard` called while another is running. Wait for completion.                 |
+| `THREEDS_MISSING_VERIFY_CARD_OPTION`            | MERCHANT | Provide `nonce`, `bin`, and `amount` to verifyCard.                                |
+| `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | MERCHANT | Nonce invalid or already consumed. Use a fresh nonce from tokenization.            |
+| `THREEDS_CARDINAL_SDK_CANCELED`                 | CUSTOMER | User closed the challenge modal. Allow retry.                                      |
 
 ## PayPal Errors
 
-| Code | Type | Resolution |
-|------|------|-----------|
-| `PAYPAL_NOT_ENABLED` | MERCHANT | Enable PayPal in Braintree control panel. |
-| `PAYPAL_SANDBOX_ACCOUNT_NOT_LINKED` | MERCHANT | Link PayPal sandbox account in Settings > Processing > PayPal. |
-| `PAYPAL_FLOW_OPTION_REQUIRED` | MERCHANT | Provide `flow: 'checkout'` or `flow: 'vault'`. |
-| `PAYPAL_FLOW_FAILED` | NETWORK | Network error creating payment. Retry. |
-| `PAYPAL_START_VAULT_INITIATED_CHECKOUT_POPUP_OPEN_FAILED` | MERCHANT | Call from direct click handler. Check popup blockers. |
-| `PAYPAL_ACCOUNT_TOKENIZATION_FAILED` | NETWORK | Tokenization failed. Retry. |
+| Code                                                      | Type     | Resolution                                                     |
+| --------------------------------------------------------- | -------- | -------------------------------------------------------------- |
+| `PAYPAL_NOT_ENABLED`                                      | MERCHANT | Enable PayPal in Braintree control panel.                      |
+| `PAYPAL_SANDBOX_ACCOUNT_NOT_LINKED`                       | MERCHANT | Link PayPal sandbox account in Settings > Processing > PayPal. |
+| `PAYPAL_FLOW_OPTION_REQUIRED`                             | MERCHANT | Provide `flow: 'checkout'` or `flow: 'vault'`.                 |
+| `PAYPAL_FLOW_FAILED`                                      | NETWORK  | Network error creating payment. Retry.                         |
+| `PAYPAL_START_VAULT_INITIATED_CHECKOUT_POPUP_OPEN_FAILED` | MERCHANT | Call from direct click handler. Check popup blockers.          |
+| `PAYPAL_ACCOUNT_TOKENIZATION_FAILED`                      | NETWORK  | Tokenization failed. Retry.                                    |
 
 ## Venmo Errors
 
-| Code | Type | Resolution |
-|------|------|-----------|
-| `VENMO_NOT_ENABLED` | MERCHANT | Enable Venmo in Braintree control panel. |
-| `VENMO_APP_CANCELED` / `VENMO_CUSTOMER_CANCELED` / `VENMO_DESKTOP_CANCELED` | CUSTOMER | User cancelled. Allow retry. |
-| `VENMO_MOBILE_POLLING_TOKENIZATION_TIMEOUT` | CUSTOMER | User took >5 minutes. Allow retry. |
-| `VENMO_TOKENIZATION_REQUEST_ACTIVE` | MERCHANT | Already tokenizing. Wait for completion. |
-| `VENMO_ECD_DISABLED` | MERCHANT | Enable Enriched Customer Data in merchant settings. |
+| Code                                                                        | Type     | Resolution                                          |
+| --------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| `VENMO_NOT_ENABLED`                                                         | MERCHANT | Enable Venmo in Braintree control panel.            |
+| `VENMO_APP_CANCELED` / `VENMO_CUSTOMER_CANCELED` / `VENMO_DESKTOP_CANCELED` | CUSTOMER | User cancelled. Allow retry.                        |
+| `VENMO_MOBILE_POLLING_TOKENIZATION_TIMEOUT`                                 | CUSTOMER | User took >5 minutes. Allow retry.                  |
+| `VENMO_TOKENIZATION_REQUEST_ACTIVE`                                         | MERCHANT | Already tokenizing. Wait for completion.            |
+| `VENMO_ECD_DISABLED`                                                        | MERCHANT | Enable Enriched Customer Data in merchant settings. |
 
 ## Apple Pay / Google Pay Errors
 
-| Code | Type | Resolution |
-|------|------|-----------|
-| `APPLE_PAY_NOT_ENABLED` | MERCHANT | Enable Apple Pay in control panel. |
+| Code                                   | Type     | Resolution                                                              |
+| -------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| `APPLE_PAY_NOT_ENABLED`                | MERCHANT | Enable Apple Pay in control panel.                                      |
 | `APPLE_PAY_MERCHANT_VALIDATION_FAILED` | MERCHANT | Register exact domain (including subdomain) in Braintree control panel. |
-| `GOOGLE_PAYMENT_NOT_ENABLED` | MERCHANT | Enable Google Pay in control panel. |
-| `GOOGLE_PAYMENT_GATEWAY_ERROR` | UNKNOWN | Check authorization, network. Inspect `err.details`. |
+| `GOOGLE_PAYMENT_NOT_ENABLED`           | MERCHANT | Enable Google Pay in control panel.                                     |
+| `GOOGLE_PAYMENT_GATEWAY_ERROR`         | UNKNOWN  | Check authorization, network. Inspect `err.details`.                    |
 
 ## Common issues
 
-| Issue | Symptom | Fix |
-|-------|---------|-----|
-| Authorization expiry | `CLIENT_AUTHORIZATION_INVALID` after ~24h | Generate fresh client token from server |
-| CSP blocking iframes | `HOSTED_FIELDS_TIMEOUT` | Add `frame-src: assets.braintreegateway.com` to CSP |
-| CSP blocking Cardinal | `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED` | Add `script-src: songbird.cardinalcommerce.com` to CSP |
-| Version mismatch | `INCOMPATIBLE_VERSIONS` | Use same SDK version for all components |
-| Popup blockers | `POPUP_OPEN_FAILED` errors | Call payment methods from direct click handlers, not async callbacks |
-| Intent/currency mismatch | PayPal payment fails silently | Ensure PayPal SDK query params match `createPayment` options |
-| Consumed nonce | `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | 3DS consumes original nonce. Always use nonce from `verifyCard` result. |
-| Rate limiting | `CLIENT_RATE_LIMITED` | Implement exponential backoff: wait 1s, 2s, 4s between retries |
+| Issue                    | Symptom                                         | Fix                                                                     |
+| ------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------- |
+| Authorization expiry     | `CLIENT_AUTHORIZATION_INVALID` after ~24h       | Generate fresh client token from server                                 |
+| CSP blocking iframes     | `HOSTED_FIELDS_TIMEOUT`                         | Add `frame-src: assets.braintreegateway.com` to CSP                     |
+| CSP blocking Cardinal    | `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED`       | Add `script-src: songbird.cardinalcommerce.com` to CSP                  |
+| Version mismatch         | `INCOMPATIBLE_VERSIONS`                         | Use same SDK version for all components                                 |
+| Popup blockers           | `POPUP_OPEN_FAILED` errors                      | Call payment methods from direct click handlers, not async callbacks    |
+| Intent/currency mismatch | PayPal payment fails silently                   | Ensure PayPal SDK query params match `createPayment` options            |
+| Consumed nonce           | `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | 3DS consumes original nonce. Always use nonce from `verifyCard` result. |
+| Rate limiting            | `CLIENT_RATE_LIMITED`                           | Implement exponential backoff: wait 1s, 2s, 4s between retries          |
 
 ## Error Handling Pattern
 
 ```javascript
 function handleError(err) {
-  if (err.type === 'CUSTOMER') {
+  if (err.type === "CUSTOMER") {
     showUserMessage(err.message);
-  } else if (err.type === 'NETWORK') {
+  } else if (err.type === "NETWORK") {
     retryWithBackoff(err);
-  } else if (err.type === 'MERCHANT') {
-    console.error('Integration error:', err.code, err.message);
+  } else if (err.type === "MERCHANT") {
+    console.error("Integration error:", err.code, err.message);
   }
 }
 ```

--- a/.well-known/agent-skills/skills/braintree-error-resolution.md
+++ b/.well-known/agent-skills/skills/braintree-error-resolution.md
@@ -1,0 +1,126 @@
+---
+name: braintree-error-resolution
+description: Complete error code reference and resolution guide for all Braintree Web SDK components - maps every error to its fix
+---
+
+# Error Resolution Guide
+
+## Error Type Taxonomy
+
+All errors are `BraintreeError` instances. Check `err.type` for category, `err.code` for specific error:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| `CUSTOMER` | End-user input/action problem | Show message to user, allow retry |
+| `MERCHANT` | Integration/configuration error | Fix integration code or Braintree settings |
+| `NETWORK` | Connectivity/timeout issue | Retry with exponential backoff |
+| `INTERNAL` | SDK bug | Report to Braintree support |
+| `UNKNOWN` | Indeterminate cause | Check `err.details`, investigate logs |
+
+## Shared Errors (All Components)
+
+| Code | Type | Resolution |
+|------|------|-----------|
+| `INCOMPATIBLE_VERSIONS` | MERCHANT | All SDK components must use the same version. Check CDN script tags or npm imports. |
+| `INSTANTIATION_OPTION_REQUIRED` | MERCHANT | Missing `client` or `authorization` in create options. |
+| `CLIENT_SCRIPT_FAILED_TO_LOAD` | NETWORK | Network error loading client script. Check internet, CSP policy, CDN availability. |
+| `METHOD_CALLED_AFTER_TEARDOWN` | MERCHANT | Instance was torn down. Create a new instance before calling methods. |
+| `INSTANTIATION_OPTION_INVALID` | MERCHANT | Bad option value passed to create. Check the option types and formats. |
+
+## Client Errors
+
+| Code | Type | Resolution |
+|------|------|-----------|
+| `CLIENT_INVALID_AUTHORIZATION` | MERCHANT | Authorization string cannot be parsed. Verify it is a valid tokenization key (`sandbox_xxx_yyy`) or base64-encoded client token. |
+| `CLIENT_AUTHORIZATION_INVALID` | MERCHANT | Token expired or deleted. **Client tokens expire ~24h.** Generate a fresh one from your server. Tokenization keys: check they are not deactivated in control panel. |
+| `CLIENT_GATEWAY_NETWORK` | NETWORK | Cannot reach Braintree gateway. Check internet, firewall, DNS. Retry with backoff. |
+| `CLIENT_REQUEST_TIMEOUT` | NETWORK | Request exceeded 60-second timeout. Check network speed. Retry. |
+| `CLIENT_REQUEST_ERROR` | NETWORK | Server returned HTTP 400+. Check `err.details` for server error message. |
+| `CLIENT_GRAPHQL_REQUEST_ERROR` | NETWORK | GraphQL error. Check `err.details` for specific GraphQL errors. |
+| `CLIENT_RATE_LIMITED` | MERCHANT | HTTP 429. Too many requests. Implement exponential backoff. |
+| `CLIENT_AUTHORIZATION_INSUFFICIENT` | MERCHANT | Authorization lacks permissions. Use client token instead of tokenization key for features requiring elevated permissions (3DS, vaulting). |
+
+## Hosted Fields Errors
+
+| Code | Type | Resolution |
+|------|------|-----------|
+| `HOSTED_FIELDS_TIMEOUT` | UNKNOWN | Iframe setup took >60s. Check CSP allows `assets.braintreegateway.com` in `frame-src`. Verify network. |
+| `HOSTED_FIELDS_INVALID_FIELD_KEY` | MERCHANT | Field name not recognized. Valid keys: `number`, `cvv`, `expirationDate`, `expirationMonth`, `expirationYear`, `postalCode`, `cardholderName`. |
+| `HOSTED_FIELDS_INVALID_FIELD_SELECTOR` | MERCHANT | CSS selector not found in DOM. Ensure container element exists before calling create. |
+| `HOSTED_FIELDS_FIELD_DUPLICATE_IFRAME` | MERCHANT | Container already has a Hosted Fields iframe. Don't call create twice on same elements. Teardown first. |
+| `HOSTED_FIELDS_FIELDS_EMPTY` | CUSTOMER | All fields empty when tokenize called. Prompt user to enter card data. |
+| `HOSTED_FIELDS_FIELDS_INVALID` | CUSTOMER | One or more fields failed validation. Check `getState()` for which fields are invalid. |
+| `HOSTED_FIELDS_TOKENIZATION_NETWORK_ERROR` | NETWORK | Gateway unreachable during tokenization. Retry. |
+| `HOSTED_FIELDS_TOKENIZATION_FAIL_ON_DUPLICATE` | CUSTOMER | Card already exists in vault. Use existing payment method or allow user to override. |
+| `HOSTED_FIELDS_TOKENIZATION_CVV_VERIFICATION_FAILED` | CUSTOMER | CVV check failed. Ask user to re-enter CVV. |
+
+## 3D Secure Errors
+
+| Code | Type | Resolution |
+|------|------|-----------|
+| `THREEDS_NOT_ENABLED` | MERCHANT | Enable 3DS in Braintree control panel. Contact support if needed. |
+| `THREEDS_CAN_NOT_USE_TOKENIZATION_KEY` | MERCHANT | 3DS requires a client token. Generate one from your server. |
+| `THREEDS_HTTPS_REQUIRED` | MERCHANT | Serve page over HTTPS. |
+| `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED` | NETWORK | CSP must allow `script-src: songbird.cardinalcommerce.com`. Check for ad blockers. |
+| `THREEDS_CARDINAL_SDK_SETUP_TIMEDOUT` | UNKNOWN | Cardinal took >60s to initialize. Check network. |
+| `THREEDS_AUTHENTICATION_IN_PROGRESS` | MERCHANT | `verifyCard` called while another is running. Wait for completion. |
+| `THREEDS_MISSING_VERIFY_CARD_OPTION` | MERCHANT | Provide `nonce`, `bin`, and `amount` to verifyCard. |
+| `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | MERCHANT | Nonce invalid or already consumed. Use a fresh nonce from tokenization. |
+| `THREEDS_CARDINAL_SDK_CANCELED` | CUSTOMER | User closed the challenge modal. Allow retry. |
+
+## PayPal Errors
+
+| Code | Type | Resolution |
+|------|------|-----------|
+| `PAYPAL_NOT_ENABLED` | MERCHANT | Enable PayPal in Braintree control panel. |
+| `PAYPAL_SANDBOX_ACCOUNT_NOT_LINKED` | MERCHANT | Link PayPal sandbox account in Settings > Processing > PayPal. |
+| `PAYPAL_FLOW_OPTION_REQUIRED` | MERCHANT | Provide `flow: 'checkout'` or `flow: 'vault'`. |
+| `PAYPAL_FLOW_FAILED` | NETWORK | Network error creating payment. Retry. |
+| `PAYPAL_START_VAULT_INITIATED_CHECKOUT_POPUP_OPEN_FAILED` | MERCHANT | Call from direct click handler. Check popup blockers. |
+| `PAYPAL_ACCOUNT_TOKENIZATION_FAILED` | NETWORK | Tokenization failed. Retry. |
+
+## Venmo Errors
+
+| Code | Type | Resolution |
+|------|------|-----------|
+| `VENMO_NOT_ENABLED` | MERCHANT | Enable Venmo in Braintree control panel. |
+| `VENMO_APP_CANCELED` / `VENMO_CUSTOMER_CANCELED` / `VENMO_DESKTOP_CANCELED` | CUSTOMER | User cancelled. Allow retry. |
+| `VENMO_MOBILE_POLLING_TOKENIZATION_TIMEOUT` | CUSTOMER | User took >5 minutes. Allow retry. |
+| `VENMO_TOKENIZATION_REQUEST_ACTIVE` | MERCHANT | Already tokenizing. Wait for completion. |
+| `VENMO_ECD_DISABLED` | MERCHANT | Enable Enriched Customer Data in merchant settings. |
+
+## Apple Pay / Google Pay Errors
+
+| Code | Type | Resolution |
+|------|------|-----------|
+| `APPLE_PAY_NOT_ENABLED` | MERCHANT | Enable Apple Pay in control panel. |
+| `APPLE_PAY_MERCHANT_VALIDATION_FAILED` | MERCHANT | Register exact domain (including subdomain) in Braintree control panel. |
+| `GOOGLE_PAYMENT_NOT_ENABLED` | MERCHANT | Enable Google Pay in control panel. |
+| `GOOGLE_PAYMENT_GATEWAY_ERROR` | UNKNOWN | Check authorization, network. Inspect `err.details`. |
+
+## Common issues
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| Authorization expiry | `CLIENT_AUTHORIZATION_INVALID` after ~24h | Generate fresh client token from server |
+| CSP blocking iframes | `HOSTED_FIELDS_TIMEOUT` | Add `frame-src: assets.braintreegateway.com` to CSP |
+| CSP blocking Cardinal | `THREEDS_CARDINAL_SDK_SCRIPT_LOAD_FAILED` | Add `script-src: songbird.cardinalcommerce.com` to CSP |
+| Version mismatch | `INCOMPATIBLE_VERSIONS` | Use same SDK version for all components |
+| Popup blockers | `POPUP_OPEN_FAILED` errors | Call payment methods from direct click handlers, not async callbacks |
+| Intent/currency mismatch | PayPal payment fails silently | Ensure PayPal SDK query params match `createPayment` options |
+| Consumed nonce | `THREEDS_LOOKUP_TOKENIZED_CARD_NOT_FOUND_ERROR` | 3DS consumes original nonce. Always use nonce from `verifyCard` result. |
+| Rate limiting | `CLIENT_RATE_LIMITED` | Implement exponential backoff: wait 1s, 2s, 4s between retries |
+
+## Error Handling Pattern
+
+```javascript
+function handleError(err) {
+  if (err.type === 'CUSTOMER') {
+    showUserMessage(err.message);
+  } else if (err.type === 'NETWORK') {
+    retryWithBackoff(err);
+  } else if (err.type === 'MERCHANT') {
+    console.error('Integration error:', err.code, err.message);
+  }
+}
+```

--- a/.well-known/agent-skills/skills/braintree-google-pay.md
+++ b/.well-known/agent-skills/skills/braintree-google-pay.md
@@ -1,0 +1,154 @@
+---
+name: braintree-google-pay
+description: Google Pay v2 integration via Google Pay API - PaymentsClient, payment data request, and response parsing
+---
+
+# Google Pay Integration
+
+## Setup
+
+### 1. Load Google Pay Script
+
+```html
+<script src="https://pay.google.com/gp/p/js/pay.js"></script>
+```
+
+### 2. Create Components
+
+```javascript
+var paymentsClient = new google.payments.api.PaymentsClient({
+  environment: 'TEST'   // 'TEST' or 'PRODUCTION'
+});
+
+braintree.client.create({ authorization: CLIENT_TOKEN })
+  .then(function (clientInstance) {
+    return braintree.googlePayment.create({
+      client: clientInstance,
+      googlePayVersion: 2,                    // Required: use v2
+      googleMerchantId: 'your-merchant-id'    // Required for PRODUCTION
+    });
+  })
+  .then(function (googlePaymentInstance) {
+    // Ready
+  });
+```
+
+### 3. Check Readiness
+
+```javascript
+paymentsClient.isReadyToPay({
+  apiVersion: 2,
+  apiVersionMinor: 0,
+  allowedPaymentMethods: googlePaymentInstance.createPaymentDataRequest().allowedPaymentMethods
+}).then(function (response) {
+  if (response.result) {
+    document.getElementById('google-pay-button').style.display = 'block';
+  }
+});
+```
+
+### 4. Handle Payment
+
+```javascript
+document.getElementById('google-pay-button').addEventListener('click', function () {
+  var paymentDataRequest = googlePaymentInstance.createPaymentDataRequest({
+    transactionInfo: {
+      currencyCode: 'USD',
+      totalPriceStatus: 'FINAL',
+      totalPrice: '100.00'    // Must be a string
+    }
+  });
+
+  paymentsClient.loadPaymentData(paymentDataRequest)
+    .then(function (paymentData) {
+      return googlePaymentInstance.parseResponse(paymentData);
+    })
+    .then(function (result) {
+      // result.nonce -- send to server
+      // result.type -- 'AndroidPayCard' or 'PayPalAccount'
+      // result.details.cardType, result.details.lastFour, result.details.bin
+      submitNonceToServer(result.nonce);
+    })
+    .catch(function (err) {
+      if (err.statusCode === 'CANCELED') {
+        console.log('User cancelled');
+      } else {
+        console.error(err);
+      }
+    });
+});
+```
+
+## Adding Billing/Shipping Address
+
+`createPaymentDataRequest` merges top-level keys only. Modify nested objects after creation:
+
+```javascript
+var request = googlePaymentInstance.createPaymentDataRequest({
+  transactionInfo: { currencyCode: 'USD', totalPriceStatus: 'FINAL', totalPrice: '25.00' }
+});
+
+// Add billing address requirement
+var cardMethod = request.allowedPaymentMethods[0];
+cardMethod.parameters.billingAddressRequired = true;
+cardMethod.parameters.billingAddressParameters = {
+  format: 'FULL',
+  phoneNumberRequired: true
+};
+
+// Add shipping
+request.shippingAddressRequired = true;
+request.shippingAddressParameters = { allowedCountryCodes: ['US', 'CA'] };
+request.emailRequired = true;
+
+paymentsClient.loadPaymentData(request).then(/* ... */);
+```
+
+## PayPal via Google Pay
+
+When the user pays with a PayPal account through Google Pay, `parseResponse` returns:
+
+```javascript
+{ nonce: 'tokenpaypal_xxx', type: 'PayPalAccount', description: 'PayPal' }
+```
+
+No additional configuration needed -- PayPal is automatically available if enabled.
+
+## Production Checklist
+
+1. Set `PaymentsClient` environment to `'PRODUCTION'`
+2. Provide `googleMerchantId` from Google Pay Business Console
+3. Enable Google Pay in Braintree control panel
+4. Ensure HTTPS
+
+## Common Errors
+
+| Code | Type | Fix |
+|------|------|-----|
+| `GOOGLE_PAYMENT_NOT_ENABLED` | MERCHANT | Enable Google Pay in Braintree control panel |
+| `GOOGLE_PAYMENT_UNSUPPORTED_VERSION` | MERCHANT | Use `googlePayVersion: 2` (or 1) |
+| `GOOGLE_PAYMENT_GATEWAY_ERROR` | UNKNOWN | Check authorization validity, inspect err.details |
+
+## Common issues
+
+1. **`totalPrice` must be a string:** `'100.00'` not `100.00`
+2. **`googleMerchantId` not needed for TEST:** Only required in `'PRODUCTION'` environment
+3. **v1 is deprecated:** Always use `googlePayVersion: 2` for new integrations
+4. **DEVELOPER_ERROR from Google:** Usually means malformed `transactionInfo` or missing required fields
+
+## Migration from v1 to v2
+
+```javascript
+// OLD (v1, deprecated):
+braintree.googlePayment.create({ client: clientInstance });
+// googlePayVersion defaults to 1
+
+// NEW (v2):
+braintree.googlePayment.create({
+  client: clientInstance,
+  googlePayVersion: 2,
+  googleMerchantId: 'your-id'  // Required for production
+});
+```
+
+Response format changed: v1 used `paymentMethodToken.token`, v2 uses `paymentMethodData.tokenizationData.token`. The `parseResponse` method handles both.

--- a/.well-known/agent-skills/skills/braintree-google-pay.md
+++ b/.well-known/agent-skills/skills/braintree-google-pay.md
@@ -17,15 +17,16 @@ description: Google Pay v2 integration via Google Pay API - PaymentsClient, paym
 
 ```javascript
 var paymentsClient = new google.payments.api.PaymentsClient({
-  environment: 'TEST'   // 'TEST' or 'PRODUCTION'
+  environment: "TEST", // 'TEST' or 'PRODUCTION'
 });
 
-braintree.client.create({ authorization: CLIENT_TOKEN })
+braintree.client
+  .create({ authorization: CLIENT_TOKEN })
   .then(function (clientInstance) {
     return braintree.googlePayment.create({
       client: clientInstance,
-      googlePayVersion: 2,                    // Required: use v2
-      googleMerchantId: 'your-merchant-id'    // Required for PRODUCTION
+      googlePayVersion: 2, // Required: use v2
+      googleMerchantId: "your-merchant-id", // Required for PRODUCTION
     });
   })
   .then(function (googlePaymentInstance) {
@@ -36,47 +37,53 @@ braintree.client.create({ authorization: CLIENT_TOKEN })
 ### 3. Check Readiness
 
 ```javascript
-paymentsClient.isReadyToPay({
-  apiVersion: 2,
-  apiVersionMinor: 0,
-  allowedPaymentMethods: googlePaymentInstance.createPaymentDataRequest().allowedPaymentMethods
-}).then(function (response) {
-  if (response.result) {
-    document.getElementById('google-pay-button').style.display = 'block';
-  }
-});
+paymentsClient
+  .isReadyToPay({
+    apiVersion: 2,
+    apiVersionMinor: 0,
+    allowedPaymentMethods:
+      googlePaymentInstance.createPaymentDataRequest().allowedPaymentMethods,
+  })
+  .then(function (response) {
+    if (response.result) {
+      document.getElementById("google-pay-button").style.display = "block";
+    }
+  });
 ```
 
 ### 4. Handle Payment
 
 ```javascript
-document.getElementById('google-pay-button').addEventListener('click', function () {
-  var paymentDataRequest = googlePaymentInstance.createPaymentDataRequest({
-    transactionInfo: {
-      currencyCode: 'USD',
-      totalPriceStatus: 'FINAL',
-      totalPrice: '100.00'    // Must be a string
-    }
-  });
-
-  paymentsClient.loadPaymentData(paymentDataRequest)
-    .then(function (paymentData) {
-      return googlePaymentInstance.parseResponse(paymentData);
-    })
-    .then(function (result) {
-      // result.nonce -- send to server
-      // result.type -- 'AndroidPayCard' or 'PayPalAccount'
-      // result.details.cardType, result.details.lastFour, result.details.bin
-      submitNonceToServer(result.nonce);
-    })
-    .catch(function (err) {
-      if (err.statusCode === 'CANCELED') {
-        console.log('User cancelled');
-      } else {
-        console.error(err);
-      }
+document
+  .getElementById("google-pay-button")
+  .addEventListener("click", function () {
+    var paymentDataRequest = googlePaymentInstance.createPaymentDataRequest({
+      transactionInfo: {
+        currencyCode: "USD",
+        totalPriceStatus: "FINAL",
+        totalPrice: "100.00", // Must be a string
+      },
     });
-});
+
+    paymentsClient
+      .loadPaymentData(paymentDataRequest)
+      .then(function (paymentData) {
+        return googlePaymentInstance.parseResponse(paymentData);
+      })
+      .then(function (result) {
+        // result.nonce -- send to server
+        // result.type -- 'AndroidPayCard' or 'PayPalAccount'
+        // result.details.cardType, result.details.lastFour, result.details.bin
+        submitNonceToServer(result.nonce);
+      })
+      .catch(function (err) {
+        if (err.statusCode === "CANCELED") {
+          console.log("User cancelled");
+        } else {
+          console.error(err);
+        }
+      });
+  });
 ```
 
 ## Adding Billing/Shipping Address
@@ -85,20 +92,24 @@ document.getElementById('google-pay-button').addEventListener('click', function 
 
 ```javascript
 var request = googlePaymentInstance.createPaymentDataRequest({
-  transactionInfo: { currencyCode: 'USD', totalPriceStatus: 'FINAL', totalPrice: '25.00' }
+  transactionInfo: {
+    currencyCode: "USD",
+    totalPriceStatus: "FINAL",
+    totalPrice: "25.00",
+  },
 });
 
 // Add billing address requirement
 var cardMethod = request.allowedPaymentMethods[0];
 cardMethod.parameters.billingAddressRequired = true;
 cardMethod.parameters.billingAddressParameters = {
-  format: 'FULL',
-  phoneNumberRequired: true
+  format: "FULL",
+  phoneNumberRequired: true,
 };
 
 // Add shipping
 request.shippingAddressRequired = true;
-request.shippingAddressParameters = { allowedCountryCodes: ['US', 'CA'] };
+request.shippingAddressParameters = { allowedCountryCodes: ["US", "CA"] };
 request.emailRequired = true;
 
 paymentsClient.loadPaymentData(request).then(/* ... */);
@@ -123,11 +134,11 @@ No additional configuration needed -- PayPal is automatically available if enabl
 
 ## Common Errors
 
-| Code | Type | Fix |
-|------|------|-----|
-| `GOOGLE_PAYMENT_NOT_ENABLED` | MERCHANT | Enable Google Pay in Braintree control panel |
-| `GOOGLE_PAYMENT_UNSUPPORTED_VERSION` | MERCHANT | Use `googlePayVersion: 2` (or 1) |
-| `GOOGLE_PAYMENT_GATEWAY_ERROR` | UNKNOWN | Check authorization validity, inspect err.details |
+| Code                                 | Type     | Fix                                               |
+| ------------------------------------ | -------- | ------------------------------------------------- |
+| `GOOGLE_PAYMENT_NOT_ENABLED`         | MERCHANT | Enable Google Pay in Braintree control panel      |
+| `GOOGLE_PAYMENT_UNSUPPORTED_VERSION` | MERCHANT | Use `googlePayVersion: 2` (or 1)                  |
+| `GOOGLE_PAYMENT_GATEWAY_ERROR`       | UNKNOWN  | Check authorization validity, inspect err.details |
 
 ## Common issues
 
@@ -147,7 +158,7 @@ braintree.googlePayment.create({ client: clientInstance });
 braintree.googlePayment.create({
   client: clientInstance,
   googlePayVersion: 2,
-  googleMerchantId: 'your-id'  // Required for production
+  googleMerchantId: "your-id", // Required for production
 });
 ```
 

--- a/.well-known/agent-skills/skills/braintree-migration-guide.md
+++ b/.well-known/agent-skills/skills/braintree-migration-guide.md
@@ -1,0 +1,195 @@
+---
+name: braintree-migration-guide
+description: Version migration paths, deprecated component replacements, and breaking changes for Braintree Web SDK
+---
+
+# Migration Guide
+
+## Deprecated Components
+
+| Component | Replacement | Status |
+|-----------|-------------|--------|
+| `paypal` | `paypalCheckout` | Deprecated since v3.16.0. Requires PayPal JS SDK. |
+| `masterpass` | None | Removed. Masterpass discontinued by Mastercard. |
+| `visaCheckout` | None | Removed. Visa Checkout replaced by Click to Pay. |
+| `preferredPaymentMethods` | None | Removed. |
+
+## 3D Secure v1 to v2
+
+**Removed in v3.91.0.** Use version 2 for all integrations.
+
+```javascript
+// OLD (v1, removed):
+braintree.threeDSecure.create({
+  client: clientInstance
+  // version defaults to 1
+}).then(function (threeDSecureInstance) {
+  threeDSecureInstance.verifyCard({
+    nonce: nonce,
+    amount: '100.00'
+  }, callback);
+});
+
+// NEW (v2):
+braintree.threeDSecure.create({
+  client: clientInstance,
+  version: '2'               // Required
+}).then(function (threeDSecureInstance) {
+  // Must register lookup-complete handler
+  threeDSecureInstance.on('lookup-complete', function (data, next) {
+    next();  // Proceed with challenge if needed
+  });
+
+  threeDSecureInstance.verifyCard({
+    nonce: nonce,
+    bin: bin,                 // Now required
+    amount: '100.00'
+  }, callback);
+});
+```
+
+**Key differences:**
+- `version: '2'` required in create options
+- `bin` parameter required in `verifyCard`
+- `lookup-complete` event handler replaces automatic flow
+- Cardinal Songbird.js loaded automatically
+- `requestedExemptionType` replaces deprecated `exemptionRequested`
+
+## paypal to paypal-checkout
+
+```javascript
+// OLD (deprecated paypal component):
+braintree.paypal.create({ client: clientInstance })
+  .then(function (paypalInstance) {
+    paypalInstance.tokenize({ flow: 'checkout' }, callback);
+  });
+
+// NEW (paypal-checkout):
+// 1. Add to HTML: <script src="https://www.paypal.com/sdk/js?client-id=YOUR_ID"></script>
+braintree.paypalCheckout.create({ client: clientInstance })
+  .then(function (ppCheckout) {
+    paypal.Buttons({
+      createOrder: function () {
+        return ppCheckout.createPayment({ flow: 'checkout', amount: '10.00', currency: 'USD' });
+      },
+      onApprove: function (data) {
+        return ppCheckout.tokenizePayment(data).then(function (payload) {
+          submitToServer(payload.nonce);
+        });
+      }
+    }).render('#paypal-button');
+  });
+```
+
+## paypal-checkout to paypal-checkout-v6
+
+New session-based API introduced in v3.135.0:
+
+- `paypalCheckoutV6` requires **client token** (not tokenization key)
+- Uses `loadPayPalSDK()` instead of external `<script>` tag
+- Session-based flow with `createCheckoutWithVaultSession` (v3.138.0)
+- More integrated with PayPal Web SDK v6
+
+## Google Pay v1 to v2
+
+```javascript
+// OLD (v1, deprecated):
+braintree.googlePayment.create({
+  client: clientInstance
+  // googlePayVersion defaults to 1
+});
+
+// NEW (v2):
+braintree.googlePayment.create({
+  client: clientInstance,
+  googlePayVersion: 2,
+  googleMerchantId: 'BCR2DN...'   // Required for PRODUCTION
+});
+```
+
+**Breaking changes in v3.29.0:**
+- Switched from iframe-based to Google Pay.js script tag
+- Removed methods: `isSupported`, `tokenize`, `createSupportedPaymentMethodsConfiguration`, `on`
+- Error codes renamed: `PAY_WITH_GOOGLE_*` to `GOOGLE_PAYMENT_*`
+
+## Data Collector Changes
+
+| Version | Change |
+|---------|--------|
+| v3.114.0 | Kount deprecated. Data Collector now uses Fraudnet only. |
+| v3.83.0 | `clientMetadataId` renamed to `riskCorrelationId` |
+| v3.82.0 | `correlationId` renamed to `clientMetadataId` |
+
+```javascript
+// Current usage:
+braintree.dataCollector.create({
+  client: clientInstance
+  // No kount-specific options needed
+}).then(function (dataCollectorInstance) {
+  var deviceData = dataCollectorInstance.deviceData;  // JSON string
+  // Send with transaction
+});
+```
+
+## Hosted Fields Changes
+
+| Version | Change |
+|---------|--------|
+| v3.136.0 | 8-digit BIN support added to `binAvailable` event |
+| v3.134.0 | CSP SRI hashes for hosted field scripts |
+| v3.13.0 | **Breaking:** Invalid field keys now throw errors (previously silently ignored) |
+
+## 3DS Exemption Changes (v3.91.0+)
+
+```javascript
+// OLD (deprecated):
+threeDSecureInstance.verifyCard({
+  nonce: nonce,
+  amount: '10.00',
+  exemptionRequested: true       // Deprecated
+});
+
+// NEW:
+threeDSecureInstance.verifyCard({
+  nonce: nonce,
+  bin: bin,                      // Now required
+  amount: '10.00',
+  requestedExemptionType: 'low_value'  // or 'transaction_risk_analysis'
+});
+```
+
+## Payment Request Changes (v3.28.0)
+
+```javascript
+// OLD:
+{ payWithGoogle: { /* ... */ } }
+
+// NEW:
+{ googlePay: { /* ... */ } }
+```
+
+## Recent Feature Additions
+
+| Version | Feature |
+|---------|---------|
+| v3.138.0 | PayPal Checkout v6: `createCheckoutWithVaultSession` |
+| v3.137.0 | Alternative Payment: Cryptocurrency support |
+| v3.136.0 | Venmo: `riskCorrelationId` option |
+| v3.135.0 | New `paypalCheckoutV6` component; 8-digit BIN verification |
+| v3.134.0 | Instant Verification: `getAchMandateDetails`; CSP SRI hashes |
+| v3.133.0 | Venmo: iOS mobile web polling fix; Local Payment: Swish support |
+
+## Removed Platform Support
+
+| Version | Removal |
+|---------|---------|
+| v3.135.0 | Bower package manager support removed |
+| v3.92.2 | IE9 support dropped; Promise polyfill removed |
+
+## Version Compatibility Check
+
+All components must use the same SDK version. Mixing produces `INCOMPATIBLE_VERSIONS`. When upgrading:
+
+1. Update all `braintree-web` imports/CDN scripts simultaneously
+2. Clear browser cache (CDN scripts may be cached)
+3. Test all payment flows after upgrade

--- a/.well-known/agent-skills/skills/braintree-migration-guide.md
+++ b/.well-known/agent-skills/skills/braintree-migration-guide.md
@@ -7,12 +7,12 @@ description: Version migration paths, deprecated component replacements, and bre
 
 ## Deprecated Components
 
-| Component | Replacement | Status |
-|-----------|-------------|--------|
-| `paypal` | `paypalCheckout` | Deprecated since v3.16.0. Requires PayPal JS SDK. |
-| `masterpass` | None | Removed. Masterpass discontinued by Mastercard. |
-| `visaCheckout` | None | Removed. Visa Checkout replaced by Click to Pay. |
-| `preferredPaymentMethods` | None | Removed. |
+| Component                 | Replacement      | Status                                            |
+| ------------------------- | ---------------- | ------------------------------------------------- |
+| `paypal`                  | `paypalCheckout` | Deprecated since v3.16.0. Requires PayPal JS SDK. |
+| `masterpass`              | None             | Removed. Masterpass discontinued by Mastercard.   |
+| `visaCheckout`            | None             | Removed. Visa Checkout replaced by Click to Pay.  |
+| `preferredPaymentMethods` | None             | Removed.                                          |
 
 ## 3D Secure v1 to v2
 
@@ -20,35 +20,46 @@ description: Version migration paths, deprecated component replacements, and bre
 
 ```javascript
 // OLD (v1, removed):
-braintree.threeDSecure.create({
-  client: clientInstance
-  // version defaults to 1
-}).then(function (threeDSecureInstance) {
-  threeDSecureInstance.verifyCard({
-    nonce: nonce,
-    amount: '100.00'
-  }, callback);
-});
-
-// NEW (v2):
-braintree.threeDSecure.create({
-  client: clientInstance,
-  version: '2'               // Required
-}).then(function (threeDSecureInstance) {
-  // Must register lookup-complete handler
-  threeDSecureInstance.on('lookup-complete', function (data, next) {
-    next();  // Proceed with challenge if needed
+braintree.threeDSecure
+  .create({
+    client: clientInstance,
+    // version defaults to 1
+  })
+  .then(function (threeDSecureInstance) {
+    threeDSecureInstance.verifyCard(
+      {
+        nonce: nonce,
+        amount: "100.00",
+      },
+      callback
+    );
   });
 
-  threeDSecureInstance.verifyCard({
-    nonce: nonce,
-    bin: bin,                 // Now required
-    amount: '100.00'
-  }, callback);
-});
+// NEW (v2):
+braintree.threeDSecure
+  .create({
+    client: clientInstance,
+    version: "2", // Required
+  })
+  .then(function (threeDSecureInstance) {
+    // Must register lookup-complete handler
+    threeDSecureInstance.on("lookup-complete", function (data, next) {
+      next(); // Proceed with challenge if needed
+    });
+
+    threeDSecureInstance.verifyCard(
+      {
+        nonce: nonce,
+        bin: bin, // Now required
+        amount: "100.00",
+      },
+      callback
+    );
+  });
 ```
 
 **Key differences:**
+
 - `version: '2'` required in create options
 - `bin` parameter required in `verifyCard`
 - `lookup-complete` event handler replaces automatic flow
@@ -59,25 +70,33 @@ braintree.threeDSecure.create({
 
 ```javascript
 // OLD (deprecated paypal component):
-braintree.paypal.create({ client: clientInstance })
+braintree.paypal
+  .create({ client: clientInstance })
   .then(function (paypalInstance) {
-    paypalInstance.tokenize({ flow: 'checkout' }, callback);
+    paypalInstance.tokenize({ flow: "checkout" }, callback);
   });
 
 // NEW (paypal-checkout):
 // 1. Add to HTML: <script src="https://www.paypal.com/sdk/js?client-id=YOUR_ID"></script>
-braintree.paypalCheckout.create({ client: clientInstance })
+braintree.paypalCheckout
+  .create({ client: clientInstance })
   .then(function (ppCheckout) {
-    paypal.Buttons({
-      createOrder: function () {
-        return ppCheckout.createPayment({ flow: 'checkout', amount: '10.00', currency: 'USD' });
-      },
-      onApprove: function (data) {
-        return ppCheckout.tokenizePayment(data).then(function (payload) {
-          submitToServer(payload.nonce);
-        });
-      }
-    }).render('#paypal-button');
+    paypal
+      .Buttons({
+        createOrder: function () {
+          return ppCheckout.createPayment({
+            flow: "checkout",
+            amount: "10.00",
+            currency: "USD",
+          });
+        },
+        onApprove: function (data) {
+          return ppCheckout.tokenizePayment(data).then(function (payload) {
+            submitToServer(payload.nonce);
+          });
+        },
+      })
+      .render("#paypal-button");
   });
 ```
 
@@ -95,7 +114,7 @@ New session-based API introduced in v3.135.0:
 ```javascript
 // OLD (v1, deprecated):
 braintree.googlePayment.create({
-  client: clientInstance
+  client: clientInstance,
   // googlePayVersion defaults to 1
 });
 
@@ -103,41 +122,44 @@ braintree.googlePayment.create({
 braintree.googlePayment.create({
   client: clientInstance,
   googlePayVersion: 2,
-  googleMerchantId: 'BCR2DN...'   // Required for PRODUCTION
+  googleMerchantId: "BCR2DN...", // Required for PRODUCTION
 });
 ```
 
 **Breaking changes in v3.29.0:**
+
 - Switched from iframe-based to Google Pay.js script tag
 - Removed methods: `isSupported`, `tokenize`, `createSupportedPaymentMethodsConfiguration`, `on`
 - Error codes renamed: `PAY_WITH_GOOGLE_*` to `GOOGLE_PAYMENT_*`
 
 ## Data Collector Changes
 
-| Version | Change |
-|---------|--------|
+| Version  | Change                                                   |
+| -------- | -------------------------------------------------------- |
 | v3.114.0 | Kount deprecated. Data Collector now uses Fraudnet only. |
-| v3.83.0 | `clientMetadataId` renamed to `riskCorrelationId` |
-| v3.82.0 | `correlationId` renamed to `clientMetadataId` |
+| v3.83.0  | `clientMetadataId` renamed to `riskCorrelationId`        |
+| v3.82.0  | `correlationId` renamed to `clientMetadataId`            |
 
 ```javascript
 // Current usage:
-braintree.dataCollector.create({
-  client: clientInstance
-  // No kount-specific options needed
-}).then(function (dataCollectorInstance) {
-  var deviceData = dataCollectorInstance.deviceData;  // JSON string
-  // Send with transaction
-});
+braintree.dataCollector
+  .create({
+    client: clientInstance,
+    // No kount-specific options needed
+  })
+  .then(function (dataCollectorInstance) {
+    var deviceData = dataCollectorInstance.deviceData; // JSON string
+    // Send with transaction
+  });
 ```
 
 ## Hosted Fields Changes
 
-| Version | Change |
-|---------|--------|
-| v3.136.0 | 8-digit BIN support added to `binAvailable` event |
-| v3.134.0 | CSP SRI hashes for hosted field scripts |
-| v3.13.0 | **Breaking:** Invalid field keys now throw errors (previously silently ignored) |
+| Version  | Change                                                                          |
+| -------- | ------------------------------------------------------------------------------- |
+| v3.136.0 | 8-digit BIN support added to `binAvailable` event                               |
+| v3.134.0 | CSP SRI hashes for hosted field scripts                                         |
+| v3.13.0  | **Breaking:** Invalid field keys now throw errors (previously silently ignored) |
 
 ## 3DS Exemption Changes (v3.91.0+)
 
@@ -145,16 +167,16 @@ braintree.dataCollector.create({
 // OLD (deprecated):
 threeDSecureInstance.verifyCard({
   nonce: nonce,
-  amount: '10.00',
-  exemptionRequested: true       // Deprecated
+  amount: "10.00",
+  exemptionRequested: true, // Deprecated
 });
 
 // NEW:
 threeDSecureInstance.verifyCard({
   nonce: nonce,
-  bin: bin,                      // Now required
-  amount: '10.00',
-  requestedExemptionType: 'low_value'  // or 'transaction_risk_analysis'
+  bin: bin, // Now required
+  amount: "10.00",
+  requestedExemptionType: "low_value", // or 'transaction_risk_analysis'
 });
 ```
 
@@ -162,29 +184,37 @@ threeDSecureInstance.verifyCard({
 
 ```javascript
 // OLD:
-{ payWithGoogle: { /* ... */ } }
+{
+  payWithGoogle: {
+    /* ... */
+  }
+}
 
 // NEW:
-{ googlePay: { /* ... */ } }
+{
+  googlePay: {
+    /* ... */
+  }
+}
 ```
 
 ## Recent Feature Additions
 
-| Version | Feature |
-|---------|---------|
-| v3.138.0 | PayPal Checkout v6: `createCheckoutWithVaultSession` |
-| v3.137.0 | Alternative Payment: Cryptocurrency support |
-| v3.136.0 | Venmo: `riskCorrelationId` option |
-| v3.135.0 | New `paypalCheckoutV6` component; 8-digit BIN verification |
-| v3.134.0 | Instant Verification: `getAchMandateDetails`; CSP SRI hashes |
+| Version  | Feature                                                         |
+| -------- | --------------------------------------------------------------- |
+| v3.138.0 | PayPal Checkout v6: `createCheckoutWithVaultSession`            |
+| v3.137.0 | Alternative Payment: Cryptocurrency support                     |
+| v3.136.0 | Venmo: `riskCorrelationId` option                               |
+| v3.135.0 | New `paypalCheckoutV6` component; 8-digit BIN verification      |
+| v3.134.0 | Instant Verification: `getAchMandateDetails`; CSP SRI hashes    |
 | v3.133.0 | Venmo: iOS mobile web polling fix; Local Payment: Swish support |
 
 ## Removed Platform Support
 
-| Version | Removal |
-|---------|---------|
-| v3.135.0 | Bower package manager support removed |
-| v3.92.2 | IE9 support dropped; Promise polyfill removed |
+| Version  | Removal                                       |
+| -------- | --------------------------------------------- |
+| v3.135.0 | Bower package manager support removed         |
+| v3.92.2  | IE9 support dropped; Promise polyfill removed |
 
 ## Version Compatibility Check
 

--- a/.well-known/agent-skills/skills/braintree-paypal.md
+++ b/.well-known/agent-skills/skills/braintree-paypal.md
@@ -7,11 +7,11 @@ description: PayPal integration via paypal-checkout and paypal-checkout-v6 - che
 
 ## Component Choice
 
-| Component | Status | SDK Loading | Auth Required |
-|-----------|--------|-------------|---------------|
-| `paypalCheckout` | Stable, recommended | External `<script>` tag | Tokenization key or client token |
-| `paypalCheckoutV6` | Newer, session-based | `loadPayPalSDK()` method | Client token only |
-| `paypal` | **Deprecated** | Built-in popup | Do not use |
+| Component          | Status               | SDK Loading              | Auth Required                    |
+| ------------------ | -------------------- | ------------------------ | -------------------------------- |
+| `paypalCheckout`   | Stable, recommended  | External `<script>` tag  | Tokenization key or client token |
+| `paypalCheckoutV6` | Newer, session-based | `loadPayPalSDK()` method | Client token only                |
+| `paypal`           | **Deprecated**       | Built-in popup           | Do not use                       |
 
 ## PayPal Checkout (paypal-checkout)
 
@@ -30,51 +30,62 @@ Load PayPal JS SDK on the page. Query params must match `createPayment` options:
 ### Checkout Flow (One-Time Payment)
 
 ```javascript
-braintree.client.create({ authorization: CLIENT_TOKEN })
+braintree.client
+  .create({ authorization: CLIENT_TOKEN })
   .then(function (clientInstance) {
     return braintree.paypalCheckout.create({ client: clientInstance });
   })
   .then(function (paypalCheckoutInstance) {
-    return paypal.Buttons({
-      createOrder: function () {
-        return paypalCheckoutInstance.createPayment({
-          flow: 'checkout',
-          amount: '10.00',
-          currency: 'USD',
-          intent: 'capture'   // Must match SDK intent param
-        });
-      },
-      onApprove: function (data) {
-        return paypalCheckoutInstance.tokenizePayment(data)
-          .then(function (payload) {
-            // payload.nonce -- send to server
-            submitNonceToServer(payload.nonce);
+    return paypal
+      .Buttons({
+        createOrder: function () {
+          return paypalCheckoutInstance.createPayment({
+            flow: "checkout",
+            amount: "10.00",
+            currency: "USD",
+            intent: "capture", // Must match SDK intent param
           });
-      },
-      onCancel: function () { console.log('Cancelled'); },
-      onError: function (err) { console.error(err); }
-    }).render('#paypal-button');
+        },
+        onApprove: function (data) {
+          return paypalCheckoutInstance
+            .tokenizePayment(data)
+            .then(function (payload) {
+              // payload.nonce -- send to server
+              submitNonceToServer(payload.nonce);
+            });
+        },
+        onCancel: function () {
+          console.log("Cancelled");
+        },
+        onError: function (err) {
+          console.error(err);
+        },
+      })
+      .render("#paypal-button");
   });
 ```
 
 ### Vault Flow (Save PayPal Account)
 
 ```javascript
-paypal.Buttons({
-  createBillingAgreement: function () {
-    return paypalCheckoutInstance.createPayment({
-      flow: 'vault',
-      billingAgreementDescription: 'Monthly subscription'
-    });
-  },
-  onApprove: function (data) {
-    return paypalCheckoutInstance.tokenizePayment(data)
-      .then(function (payload) {
-        // Nonce represents vaulted PayPal account
-        submitNonceToServer(payload.nonce);
+paypal
+  .Buttons({
+    createBillingAgreement: function () {
+      return paypalCheckoutInstance.createPayment({
+        flow: "vault",
+        billingAgreementDescription: "Monthly subscription",
       });
-  }
-}).render('#paypal-button');
+    },
+    onApprove: function (data) {
+      return paypalCheckoutInstance
+        .tokenizePayment(data)
+        .then(function (payload) {
+          // Nonce represents vaulted PayPal account
+          submitNonceToServer(payload.nonce);
+        });
+    },
+  })
+  .render("#paypal-button");
 ```
 
 ### Vault Initiated Checkout (VIC)
@@ -83,38 +94,45 @@ For repeat customers with vaulted PayPal accounts:
 
 ```javascript
 // MUST be called from a click handler (popup blocker prevention)
-buyAgainButton.addEventListener('click', function () {
-  paypalCheckoutInstance.startVaultInitiatedCheckout({
-    vaultInitiatedCheckoutPaymentMethodToken: savedToken,
-    amount: '19.99',
-    currency: 'USD'
-  }).then(function (payload) {
-    submitNonceToServer(payload.nonce);
-  }).catch(function (err) {
-    if (err.code === 'PAYPAL_START_VAULT_INITIATED_CHECKOUT_CANCELED') {
-      // Customer cancelled
-    }
-  });
+buyAgainButton.addEventListener("click", function () {
+  paypalCheckoutInstance
+    .startVaultInitiatedCheckout({
+      vaultInitiatedCheckoutPaymentMethodToken: savedToken,
+      amount: "19.99",
+      currency: "USD",
+    })
+    .then(function (payload) {
+      submitNonceToServer(payload.nonce);
+    })
+    .catch(function (err) {
+      if (err.code === "PAYPAL_START_VAULT_INITIATED_CHECKOUT_CANCELED") {
+        // Customer cancelled
+      }
+    });
 });
 ```
 
 ### Shipping Updates
 
 ```javascript
-paypal.Buttons({
-  createOrder: function () {
-    return paypalCheckoutInstance.createPayment({
-      flow: 'checkout', amount: '10.00', currency: 'USD'
-    });
-  },
-  onShippingChange: function (data) {
-    var newTotal = calculateShipping(data.shipping_address);
-    return paypalCheckoutInstance.updatePayment({ amount: String(newTotal) });
-  },
-  onApprove: function (data) {
-    return paypalCheckoutInstance.tokenizePayment(data);
-  }
-}).render('#paypal-button');
+paypal
+  .Buttons({
+    createOrder: function () {
+      return paypalCheckoutInstance.createPayment({
+        flow: "checkout",
+        amount: "10.00",
+        currency: "USD",
+      });
+    },
+    onShippingChange: function (data) {
+      var newTotal = calculateShipping(data.shipping_address);
+      return paypalCheckoutInstance.updatePayment({ amount: String(newTotal) });
+    },
+    onApprove: function (data) {
+      return paypalCheckoutInstance.tokenizePayment(data);
+    },
+  })
+  .render("#paypal-button");
 ```
 
 ### PayPal Credit Detection
@@ -123,27 +141,30 @@ paypal.Buttons({
 // In onApprove:
 paypalCheckoutInstance.tokenizePayment(data).then(function (payload) {
   if (payload.creditFinancingOffered) {
-    console.log('PayPal Credit used, term:', payload.creditFinancingOffered.term);
+    console.log(
+      "PayPal Credit used, term:",
+      payload.creditFinancingOffered.term
+    );
   }
 });
 ```
 
 ## Common Errors
 
-| Code | Type | Fix |
-|------|------|-----|
-| `PAYPAL_NOT_ENABLED` | MERCHANT | Enable PayPal in Braintree control panel |
-| `PAYPAL_SANDBOX_ACCOUNT_NOT_LINKED` | MERCHANT | Link PayPal sandbox account in control panel |
-| `PAYPAL_FLOW_OPTION_REQUIRED` | MERCHANT | Provide `flow: 'checkout'` or `flow: 'vault'` |
-| `PAYPAL_FLOW_FAILED` | NETWORK | Check network, retry |
+| Code                                                      | Type     | Fix                                                |
+| --------------------------------------------------------- | -------- | -------------------------------------------------- |
+| `PAYPAL_NOT_ENABLED`                                      | MERCHANT | Enable PayPal in Braintree control panel           |
+| `PAYPAL_SANDBOX_ACCOUNT_NOT_LINKED`                       | MERCHANT | Link PayPal sandbox account in control panel       |
+| `PAYPAL_FLOW_OPTION_REQUIRED`                             | MERCHANT | Provide `flow: 'checkout'` or `flow: 'vault'`      |
+| `PAYPAL_FLOW_FAILED`                                      | NETWORK  | Check network, retry                               |
 | `PAYPAL_START_VAULT_INITIATED_CHECKOUT_POPUP_OPEN_FAILED` | MERCHANT | Call from user click handler, check popup blockers |
-| `PAYPAL_ACCOUNT_TOKENIZATION_FAILED` | NETWORK | Retry tokenization |
+| `PAYPAL_ACCOUNT_TOKENIZATION_FAILED`                      | NETWORK  | Retry tokenization                                 |
 
 ## Common issues
 
-1. **Intent mismatch:** SDK `intent` param must match `createPayment` intent. Mismatch causes silent failures.
-2. **Currency mismatch:** SDK `currency` param must match `createPayment` currency.
-3. **Popup blocking:** VIC must be called synchronously from a click handler.
+1. **Popup blocking (most common drop-off cause):** Browsers block popups that are not in the direct synchronous execution path of a user click. Never call `braintree.client.create()` or `braintree.paypalCheckout.create()` inside a click handler -- pre-initialize both at page load so that payment flows are immediate when the user clicks. Safari blocks popups by default with no user-visible error. When using Smart Payment Buttons (recommended), the PayPal JS SDK renders inside an iframe and avoids popup blocking for the main checkout flow. VIC and legacy `tokenize()` flows open popups and are especially susceptible.
+2. **Intent mismatch:** SDK `intent` param must match `createPayment` intent. Mismatch causes silent failures.
+3. **Currency mismatch:** SDK `currency` param must match `createPayment` currency.
 4. **Sandbox testing:** Link PayPal sandbox account in Braintree control panel before testing.
 
 ## Migration from Legacy `paypal` Component
@@ -151,19 +172,25 @@ paypalCheckoutInstance.tokenizePayment(data).then(function (payload) {
 ```javascript
 // OLD (deprecated):
 braintree.paypal.create({ client }).then(function (paypalInstance) {
-  paypalInstance.tokenize({ flow: 'checkout' }, callback);
+  paypalInstance.tokenize({ flow: "checkout" }, callback);
 });
 
 // NEW (paypal-checkout):
 braintree.paypalCheckout.create({ client }).then(function (ppCheckout) {
-  paypal.Buttons({
-    createOrder: function () {
-      return ppCheckout.createPayment({ flow: 'checkout', amount: '10.00', currency: 'USD' });
-    },
-    onApprove: function (data) {
-      return ppCheckout.tokenizePayment(data);
-    }
-  }).render('#paypal-button');
+  paypal
+    .Buttons({
+      createOrder: function () {
+        return ppCheckout.createPayment({
+          flow: "checkout",
+          amount: "10.00",
+          currency: "USD",
+        });
+      },
+      onApprove: function (data) {
+        return ppCheckout.tokenizePayment(data);
+      },
+    })
+    .render("#paypal-button");
 });
 ```
 

--- a/.well-known/agent-skills/skills/braintree-paypal.md
+++ b/.well-known/agent-skills/skills/braintree-paypal.md
@@ -1,0 +1,170 @@
+---
+name: braintree-paypal
+description: PayPal integration via paypal-checkout and paypal-checkout-v6 - checkout, vault, and VIC flows
+---
+
+# PayPal Integration
+
+## Component Choice
+
+| Component | Status | SDK Loading | Auth Required |
+|-----------|--------|-------------|---------------|
+| `paypalCheckout` | Stable, recommended | External `<script>` tag | Tokenization key or client token |
+| `paypalCheckoutV6` | Newer, session-based | `loadPayPalSDK()` method | Client token only |
+| `paypal` | **Deprecated** | Built-in popup | Do not use |
+
+## PayPal Checkout (paypal-checkout)
+
+### Setup
+
+Load PayPal JS SDK on the page. Query params must match `createPayment` options:
+
+```html
+<!-- Checkout flow -->
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&currency=USD&intent=capture"></script>
+
+<!-- Vault flow -->
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID&vault=true"></script>
+```
+
+### Checkout Flow (One-Time Payment)
+
+```javascript
+braintree.client.create({ authorization: CLIENT_TOKEN })
+  .then(function (clientInstance) {
+    return braintree.paypalCheckout.create({ client: clientInstance });
+  })
+  .then(function (paypalCheckoutInstance) {
+    return paypal.Buttons({
+      createOrder: function () {
+        return paypalCheckoutInstance.createPayment({
+          flow: 'checkout',
+          amount: '10.00',
+          currency: 'USD',
+          intent: 'capture'   // Must match SDK intent param
+        });
+      },
+      onApprove: function (data) {
+        return paypalCheckoutInstance.tokenizePayment(data)
+          .then(function (payload) {
+            // payload.nonce -- send to server
+            submitNonceToServer(payload.nonce);
+          });
+      },
+      onCancel: function () { console.log('Cancelled'); },
+      onError: function (err) { console.error(err); }
+    }).render('#paypal-button');
+  });
+```
+
+### Vault Flow (Save PayPal Account)
+
+```javascript
+paypal.Buttons({
+  createBillingAgreement: function () {
+    return paypalCheckoutInstance.createPayment({
+      flow: 'vault',
+      billingAgreementDescription: 'Monthly subscription'
+    });
+  },
+  onApprove: function (data) {
+    return paypalCheckoutInstance.tokenizePayment(data)
+      .then(function (payload) {
+        // Nonce represents vaulted PayPal account
+        submitNonceToServer(payload.nonce);
+      });
+  }
+}).render('#paypal-button');
+```
+
+### Vault Initiated Checkout (VIC)
+
+For repeat customers with vaulted PayPal accounts:
+
+```javascript
+// MUST be called from a click handler (popup blocker prevention)
+buyAgainButton.addEventListener('click', function () {
+  paypalCheckoutInstance.startVaultInitiatedCheckout({
+    vaultInitiatedCheckoutPaymentMethodToken: savedToken,
+    amount: '19.99',
+    currency: 'USD'
+  }).then(function (payload) {
+    submitNonceToServer(payload.nonce);
+  }).catch(function (err) {
+    if (err.code === 'PAYPAL_START_VAULT_INITIATED_CHECKOUT_CANCELED') {
+      // Customer cancelled
+    }
+  });
+});
+```
+
+### Shipping Updates
+
+```javascript
+paypal.Buttons({
+  createOrder: function () {
+    return paypalCheckoutInstance.createPayment({
+      flow: 'checkout', amount: '10.00', currency: 'USD'
+    });
+  },
+  onShippingChange: function (data) {
+    var newTotal = calculateShipping(data.shipping_address);
+    return paypalCheckoutInstance.updatePayment({ amount: String(newTotal) });
+  },
+  onApprove: function (data) {
+    return paypalCheckoutInstance.tokenizePayment(data);
+  }
+}).render('#paypal-button');
+```
+
+### PayPal Credit Detection
+
+```javascript
+// In onApprove:
+paypalCheckoutInstance.tokenizePayment(data).then(function (payload) {
+  if (payload.creditFinancingOffered) {
+    console.log('PayPal Credit used, term:', payload.creditFinancingOffered.term);
+  }
+});
+```
+
+## Common Errors
+
+| Code | Type | Fix |
+|------|------|-----|
+| `PAYPAL_NOT_ENABLED` | MERCHANT | Enable PayPal in Braintree control panel |
+| `PAYPAL_SANDBOX_ACCOUNT_NOT_LINKED` | MERCHANT | Link PayPal sandbox account in control panel |
+| `PAYPAL_FLOW_OPTION_REQUIRED` | MERCHANT | Provide `flow: 'checkout'` or `flow: 'vault'` |
+| `PAYPAL_FLOW_FAILED` | NETWORK | Check network, retry |
+| `PAYPAL_START_VAULT_INITIATED_CHECKOUT_POPUP_OPEN_FAILED` | MERCHANT | Call from user click handler, check popup blockers |
+| `PAYPAL_ACCOUNT_TOKENIZATION_FAILED` | NETWORK | Retry tokenization |
+
+## Common issues
+
+1. **Intent mismatch:** SDK `intent` param must match `createPayment` intent. Mismatch causes silent failures.
+2. **Currency mismatch:** SDK `currency` param must match `createPayment` currency.
+3. **Popup blocking:** VIC must be called synchronously from a click handler.
+4. **Sandbox testing:** Link PayPal sandbox account in Braintree control panel before testing.
+
+## Migration from Legacy `paypal` Component
+
+```javascript
+// OLD (deprecated):
+braintree.paypal.create({ client }).then(function (paypalInstance) {
+  paypalInstance.tokenize({ flow: 'checkout' }, callback);
+});
+
+// NEW (paypal-checkout):
+braintree.paypalCheckout.create({ client }).then(function (ppCheckout) {
+  paypal.Buttons({
+    createOrder: function () {
+      return ppCheckout.createPayment({ flow: 'checkout', amount: '10.00', currency: 'USD' });
+    },
+    onApprove: function (data) {
+      return ppCheckout.tokenizePayment(data);
+    }
+  }).render('#paypal-button');
+});
+```
+
+Key differences: Requires external PayPal JS SDK, button rendering managed by PayPal, separate `createPayment`/`tokenizePayment` methods.

--- a/.well-known/agent-skills/skills/braintree-sdk-overview.md
+++ b/.well-known/agent-skills/skills/braintree-sdk-overview.md
@@ -1,0 +1,123 @@
+---
+name: braintree-sdk-overview
+description: Braintree Web SDK v3 architecture, component lifecycle, authorization types, and integration guide
+---
+
+# Braintree Web SDK Overview
+
+## SDK Architecture
+
+Braintree Web SDK v3 is a modular, client-side JavaScript SDK for accepting payments. Current version: **3.138.0**.
+
+**Distribution:** npm (`braintree-web`) or CDN (`https://js.braintreegateway.com/web/{VERSION}/js/{component}.min.js`).
+
+**Module system:** CommonJS (Browserify/Webpack compatible), UMD for CDN.
+
+## Authorization Types
+
+| Type | Format | Use When |
+|------|--------|----------|
+| **Tokenization Key** | `sandbox_xxx_yyy` / `production_xxx_yyy` | Simple card tokenization; public, no expiry |
+| **Client Token** | Base64-encoded JSON | 3DS, vaulting, PayPal, customer-specific config; server-generated, expires ~24h |
+
+**General guidance:** If a component requires server interaction beyond tokenization, use a client token.
+
+## Component Selection Guide
+
+| Use Case | Component(s) |
+|----------|-------------|
+| Credit/debit card input | `hostedFields` |
+| Card + fraud prevention + 3DS | `hostedFields` + `dataCollector` + `threeDSecure` |
+| PayPal button | `paypalCheckout` (or `paypalCheckoutV6`) |
+| Venmo | `venmo` |
+| Apple Pay (Safari) | `applePay` |
+| Google Pay | `googlePayment` |
+| Local methods (iDEAL, Sofort, etc.) | `localPayment` |
+| SEPA Direct Debit | `sepa` |
+| ACH / US bank | `usBankAccount` |
+| Manage stored payments | `vaultManager` |
+
+**Deprecated (do not use):** `paypal`, `masterpass`, `visaCheckout`, `preferredPaymentMethods`.
+
+## Component Lifecycle Pattern
+
+Every component follows this creation pattern:
+
+```javascript
+braintree.componentName.create({
+  client: clientInstance,       // OR
+  authorization: 'token_here', // deferred client creation
+  // ...component options
+}, function (err, instance) {
+  // instance ready
+});
+```
+
+**Internal flow:**
+
+1. `basicComponentVerification.verify()` -- validates options, checks version compatibility
+2. `createDeferredClient.create()` -- creates client from authorization if needed
+3. Gateway configuration check -- verifies component is enabled
+4. Component initialization -- returns instance via callback/Promise
+
+**Dual API:** All public methods support both callbacks and Promises via `@braintree/wrap-promise`.
+
+## Version Compatibility
+
+All components must match the SDK version. Mixing versions produces:
+
+```
+BraintreeError {
+  type: 'MERCHANT',
+  code: 'INCOMPATIBLE_VERSIONS',
+  message: 'Client (version X) and Component (version Y) must be from same SDK version'
+}
+```
+
+**Fix:** Use the same version for all `braintree-web` imports or CDN scripts.
+
+## Client Creation
+
+The `client` component is foundational -- all other components depend on it.
+
+```javascript
+braintree.client.create({
+  authorization: CLIENT_TOKEN
+}).then(function (clientInstance) {
+  // Reuse clientInstance for all component creation
+  return Promise.all([
+    braintree.hostedFields.create({ client: clientInstance, fields: { /* ... */ } }),
+    braintree.dataCollector.create({ client: clientInstance }),
+    braintree.threeDSecure.create({ client: clientInstance, version: '2' })
+  ]);
+}).then(function (instances) {
+  var hostedFields = instances[0];
+  var dataCollector = instances[1];
+  var threeDSecure = instances[2];
+  // All ready
+});
+```
+
+## Error Types
+
+All SDK errors are `BraintreeError` instances with a `type` property:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| `CUSTOMER` | End-user problem (invalid card, cancelled) | Show message, allow retry |
+| `MERCHANT` | Integration/config error | Fix code or Braintree settings |
+| `NETWORK` | Connectivity/timeout | Implement retry with backoff |
+| `INTERNAL` | SDK bug | Report to Braintree |
+| `UNKNOWN` | Indeterminate | Inspect `err.details` |
+
+## Teardown
+
+Always clean up instances when done:
+
+```javascript
+instance.teardown(function (err) {
+  // Resources released
+});
+```
+
+Calling methods after teardown throws `METHOD_CALLED_AFTER_TEARDOWN`.

--- a/.well-known/agent-skills/skills/braintree-sdk-overview.md
+++ b/.well-known/agent-skills/skills/braintree-sdk-overview.md
@@ -15,27 +15,27 @@ Braintree Web SDK v3 is a modular, client-side JavaScript SDK for accepting paym
 
 ## Authorization Types
 
-| Type | Format | Use When |
-|------|--------|----------|
-| **Tokenization Key** | `sandbox_xxx_yyy` / `production_xxx_yyy` | Simple card tokenization; public, no expiry |
-| **Client Token** | Base64-encoded JSON | 3DS, vaulting, PayPal, customer-specific config; server-generated, expires ~24h |
+| Type                 | Format                                   | Use When                                                                        |
+| -------------------- | ---------------------------------------- | ------------------------------------------------------------------------------- |
+| **Tokenization Key** | `sandbox_xxx_yyy` / `production_xxx_yyy` | Simple card tokenization; public, no expiry                                     |
+| **Client Token**     | Base64-encoded JSON                      | 3DS, vaulting, PayPal, customer-specific config; server-generated, expires ~24h |
 
 **General guidance:** If a component requires server interaction beyond tokenization, use a client token.
 
 ## Component Selection Guide
 
-| Use Case | Component(s) |
-|----------|-------------|
-| Credit/debit card input | `hostedFields` |
-| Card + fraud prevention + 3DS | `hostedFields` + `dataCollector` + `threeDSecure` |
-| PayPal button | `paypalCheckout` (or `paypalCheckoutV6`) |
-| Venmo | `venmo` |
-| Apple Pay (Safari) | `applePay` |
-| Google Pay | `googlePayment` |
-| Local methods (iDEAL, Sofort, etc.) | `localPayment` |
-| SEPA Direct Debit | `sepa` |
-| ACH / US bank | `usBankAccount` |
-| Manage stored payments | `vaultManager` |
+| Use Case                            | Component(s)                                      |
+| ----------------------------------- | ------------------------------------------------- |
+| Credit/debit card input             | `hostedFields`                                    |
+| Card + fraud prevention + 3DS       | `hostedFields` + `dataCollector` + `threeDSecure` |
+| PayPal button                       | `paypalCheckout` (or `paypalCheckoutV6`)          |
+| Venmo                               | `venmo`                                           |
+| Apple Pay (Safari)                  | `applePay`                                        |
+| Google Pay                          | `googlePayment`                                   |
+| Local methods (iDEAL, Sofort, etc.) | `localPayment`                                    |
+| SEPA Direct Debit                   | `sepa`                                            |
+| ACH / US bank                       | `usBankAccount`                                   |
+| Manage stored payments              | `vaultManager`                                    |
 
 **Deprecated (do not use):** `paypal`, `masterpass`, `visaCheckout`, `preferredPaymentMethods`.
 
@@ -44,13 +44,16 @@ Braintree Web SDK v3 is a modular, client-side JavaScript SDK for accepting paym
 Every component follows this creation pattern:
 
 ```javascript
-braintree.componentName.create({
-  client: clientInstance,       // OR
-  authorization: 'token_here', // deferred client creation
-  // ...component options
-}, function (err, instance) {
-  // instance ready
-});
+braintree.componentName.create(
+  {
+    client: clientInstance, // OR
+    authorization: "token_here", // deferred client creation
+    // ...component options
+  },
+  function (err, instance) {
+    // instance ready
+  }
+);
 ```
 
 **Internal flow:**
@@ -80,35 +83,45 @@ BraintreeError {
 
 The `client` component is foundational -- all other components depend on it.
 
+**Pre-initialize early:** Call `braintree.client.create()` and all payment method component `create()` calls as early as possible in the page lifecycle (ideally on `DOMContentLoaded` or page load), not inside click handlers. This front-loads the gateway configuration fetch and iframe setup so that payment flows are immediate and synchronous when the user clicks. This is the single most impactful latency optimization for Braintree Web SDK integrations.
+
 ```javascript
-braintree.client.create({
-  authorization: CLIENT_TOKEN
-}).then(function (clientInstance) {
-  // Reuse clientInstance for all component creation
-  return Promise.all([
-    braintree.hostedFields.create({ client: clientInstance, fields: { /* ... */ } }),
-    braintree.dataCollector.create({ client: clientInstance }),
-    braintree.threeDSecure.create({ client: clientInstance, version: '2' })
-  ]);
-}).then(function (instances) {
-  var hostedFields = instances[0];
-  var dataCollector = instances[1];
-  var threeDSecure = instances[2];
-  // All ready
-});
+braintree.client
+  .create({
+    authorization: CLIENT_TOKEN,
+  })
+  .then(function (clientInstance) {
+    // Reuse clientInstance for all component creation
+    return Promise.all([
+      braintree.hostedFields.create({
+        client: clientInstance,
+        fields: {
+          /* ... */
+        },
+      }),
+      braintree.dataCollector.create({ client: clientInstance }),
+      braintree.threeDSecure.create({ client: clientInstance, version: "2" }),
+    ]);
+  })
+  .then(function (instances) {
+    var hostedFields = instances[0];
+    var dataCollector = instances[1];
+    var threeDSecure = instances[2];
+    // All ready
+  });
 ```
 
 ## Error Types
 
 All SDK errors are `BraintreeError` instances with a `type` property:
 
-| Type | Meaning | Action |
-|------|---------|--------|
-| `CUSTOMER` | End-user problem (invalid card, cancelled) | Show message, allow retry |
-| `MERCHANT` | Integration/config error | Fix code or Braintree settings |
-| `NETWORK` | Connectivity/timeout | Implement retry with backoff |
-| `INTERNAL` | SDK bug | Report to Braintree |
-| `UNKNOWN` | Indeterminate | Inspect `err.details` |
+| Type       | Meaning                                    | Action                         |
+| ---------- | ------------------------------------------ | ------------------------------ |
+| `CUSTOMER` | End-user problem (invalid card, cancelled) | Show message, allow retry      |
+| `MERCHANT` | Integration/config error                   | Fix code or Braintree settings |
+| `NETWORK`  | Connectivity/timeout                       | Implement retry with backoff   |
+| `INTERNAL` | SDK bug                                    | Report to Braintree            |
+| `UNKNOWN`  | Indeterminate                              | Inspect `err.details`          |
 
 ## Teardown
 
@@ -121,3 +134,7 @@ instance.teardown(function (err) {
 ```
 
 Calling methods after teardown throws `METHOD_CALLED_AFTER_TEARDOWN`.
+
+## Platform Support
+
+The Braintree Web SDK is designed for standard browser environments. It is **not tested or supported** in hybrid runtimes such as Cordova, PhoneGap, Ionic, React Native, or Electron. Features that rely on popups, app switching, or `visibilitychange` events (PayPal, Venmo) may silently fail in these environments. Use the native iOS or Android Braintree SDKs for mobile app integrations.

--- a/.well-known/agent-skills/skills/braintree-venmo.md
+++ b/.well-known/agent-skills/skills/braintree-venmo.md
@@ -7,45 +7,56 @@ description: Venmo payments across mobile and desktop - app deep-link, QR code, 
 
 ## Platform Flows
 
-| Flow | Platform | Config | Mechanism |
-|------|----------|--------|-----------|
-| Mobile app deep-link | iOS/Android | Default | Opens Venmo app, polls for result |
-| Mobile web fallback | Mobile (no app) | `mobileWebFallBack: true` | Web login in new tab |
-| Desktop QR code | Desktop | `allowDesktop: true` | Modal with QR code, phone scan |
-| Desktop web login | Desktop | `allowDesktopWebLogin: true` | Popup window login |
+| Flow                 | Platform        | Config                       | Mechanism                         |
+| -------------------- | --------------- | ---------------------------- | --------------------------------- |
+| Mobile app deep-link | iOS/Android     | Default                      | Opens Venmo app, polls for result |
+| Mobile web fallback  | Mobile (no app) | `mobileWebFallBack: true`    | Web login in new tab              |
+| Desktop QR code      | Desktop         | `allowDesktop: true`         | Modal with QR code, phone scan    |
+| Desktop web login    | Desktop         | `allowDesktopWebLogin: true` | Popup window login                |
+
+## Platform Limitations
+
+- **Venmo does not work inside iframes.** The SDK must run in a top-level browsing context, not embedded in a cross-origin iframe.
+- **Hybrid runtimes are not supported.** In Cordova, Ionic, PhoneGap, React Native, and Electron WebViews, the `tokenize()` promise will never resolve because the `visibilitychange` listener that detects app switch return never fires. Use the native iOS or Android Braintree SDK instead.
+- **In-app browsers (Facebook, Instagram, TikTok) are unreliable.** App switch deep links may fail to return to the originating in-app browser. Test thoroughly or consider disabling Venmo in these contexts using `isBrowserSupported()`.
 
 ## Basic Setup
 
 ```javascript
-braintree.venmo.create({
-  client: clientInstance,
-  allowDesktop: true,
-  paymentMethodUsage: 'single_use'  // or 'multi_use'
-}).then(function (venmoInstance) {
+braintree.venmo
+  .create({
+    client: clientInstance,
+    allowDesktop: true,
+    paymentMethodUsage: "single_use", // or 'multi_use'
+  })
+  .then(function (venmoInstance) {
+    // Check browser support first
+    if (!venmoInstance.isBrowserSupported()) {
+      console.log("Venmo not supported");
+      return;
+    }
 
-  // Check browser support first
-  if (!venmoInstance.isBrowserSupported()) {
-    console.log('Venmo not supported');
-    return;
-  }
-
-  payButton.addEventListener('click', function () {
-    venmoInstance.tokenize(function (err, payload) {
-      if (err) {
-        if (err.code === 'VENMO_CANCELED' || err.code === 'VENMO_APP_CANCELED' ||
-            err.code === 'VENMO_CUSTOMER_CANCELED' || err.code === 'VENMO_DESKTOP_CANCELED') {
-          console.log('User cancelled');
+    payButton.addEventListener("click", function () {
+      venmoInstance.tokenize(function (err, payload) {
+        if (err) {
+          if (
+            err.code === "VENMO_CANCELED" ||
+            err.code === "VENMO_APP_CANCELED" ||
+            err.code === "VENMO_CUSTOMER_CANCELED" ||
+            err.code === "VENMO_DESKTOP_CANCELED"
+          ) {
+            console.log("User cancelled");
+            return;
+          }
+          console.error(err);
           return;
         }
-        console.error(err);
-        return;
-      }
 
-      // payload.nonce, payload.details.username, payload.details.payerInfo
-      submitNonceToServer(payload.nonce);
+        // payload.nonce, payload.details.username, payload.details.payerInfo
+        submitNonceToServer(payload.nonce);
+      });
     });
   });
-});
 ```
 
 ## Configuration Options
@@ -55,91 +66,105 @@ braintree.venmo.create({
   client: clientInstance,
 
   // Mobile
-  allowNewBrowserTab: true,        // Allow new tab for auth
-  allowWebviews: true,             // Allow from webviews (Instagram, Facebook, and others)
-  mobileWebFallBack: true,         // Web login if no Venmo app
-  requireManualReturn: false,      // User must manually return to merchant
+  allowNewBrowserTab: true, // Allow new tab for auth
+  allowWebviews: true, // Allow from webviews (Instagram, Facebook, and others)
+  mobileWebFallBack: true, // Web login if no Venmo app
+  requireManualReturn: false, // User must manually return to merchant
 
   // Desktop
-  allowDesktop: true,              // Enable desktop QR code flow
-  allowDesktopWebLogin: false,     // Use popup login instead of QR
-  styleCspNonce: 'nonce-value',    // Required with CSP for injected styles
+  allowDesktop: true, // Enable desktop QR code flow
+  allowDesktopWebLogin: false, // Use popup login instead of QR
+  styleCspNonce: "nonce-value", // Required with CSP for injected styles
 
   // Payment context
-  paymentMethodUsage: 'single_use', // Required for desktop flows
-  profileId: 'venmo-profile-id',
-  displayName: 'My Business',
-  riskCorrelationId: 'custom-id',  // Custom risk tracking ID
+  paymentMethodUsage: "single_use", // Required for desktop flows
+  profileId: "venmo-profile-id",
+  displayName: "My Business",
+  riskCorrelationId: "custom-id", // Custom risk tracking ID
 
   // Enriched customer data
   collectCustomerBillingAddress: true,
   collectCustomerShippingAddress: true,
-  totalAmount: '100.00',
-  lineItems: [{
-    quantity: 1,
-    unitAmount: '100.00',
-    name: 'Premium Widget',
-    kind: 'debit'
-  }]
+  totalAmount: "100.00",
+  lineItems: [
+    {
+      quantity: 1,
+      unitAmount: "100.00",
+      name: "Premium Widget",
+      kind: "debit",
+    },
+  ],
 });
 ```
 
 ## Desktop QR Code Flow
 
 ```javascript
-braintree.venmo.create({
-  client: clientInstance,
-  allowDesktop: true,
-  paymentMethodUsage: 'single_use'
-}).then(function (venmoInstance) {
-  payButton.addEventListener('click', function () {
-    venmoInstance.tokenize(function (err, payload) {
-      // Modal with QR code appears automatically
-      // SDK polls every 1 second for approval
-      // Modal closes on approval after 2-second visual delay
-      if (err) return;
-      submitNonceToServer(payload.nonce);
+braintree.venmo
+  .create({
+    client: clientInstance,
+    allowDesktop: true,
+    paymentMethodUsage: "single_use",
+  })
+  .then(function (venmoInstance) {
+    payButton.addEventListener("click", function () {
+      venmoInstance.tokenize(function (err, payload) {
+        // Modal with QR code appears automatically
+        // SDK polls every 1 second for approval
+        // Modal closes on approval after 2-second visual delay
+        if (err) return;
+        submitNonceToServer(payload.nonce);
+      });
     });
   });
-});
 ```
 
 ## Desktop Web Login Flow
 
 ```javascript
-braintree.venmo.create({
-  client: clientInstance,
-  allowDesktopWebLogin: true,
-  paymentMethodUsage: 'single_use',
-  styleCspNonce: document.querySelector('meta[name="csp-nonce"]').content
-}).then(function (venmoInstance) {
-  // Opens popup window for Venmo web login
-  // No QR code, no polling
-});
+braintree.venmo
+  .create({
+    client: clientInstance,
+    allowDesktopWebLogin: true,
+    paymentMethodUsage: "single_use",
+    styleCspNonce: document.querySelector('meta[name="csp-nonce"]').content,
+  })
+  .then(function (venmoInstance) {
+    // Opens popup window for Venmo web login
+    // No QR code, no polling
+  });
 ```
 
 ## Enriched Customer Data
 
 ```javascript
-venmoInstance.tokenize({
-  totalAmount: '100.00',
-  collectCustomerBillingAddress: true,
-  collectCustomerShippingAddress: true,
-  isFinalAmount: true,
-  lineItems: [{
-    quantity: 1, unitAmount: '100.00', name: 'Widget', kind: 'debit'
-  }]
-}, function (err, payload) {
-  // payload.details.billingAddress
-  // payload.details.shippingAddress
-});
+venmoInstance.tokenize(
+  {
+    totalAmount: "100.00",
+    collectCustomerBillingAddress: true,
+    collectCustomerShippingAddress: true,
+    isFinalAmount: true,
+    lineItems: [
+      {
+        quantity: 1,
+        unitAmount: "100.00",
+        name: "Widget",
+        kind: "debit",
+      },
+    ],
+  },
+  function (err, payload) {
+    // payload.details.billingAddress
+    // payload.details.shippingAddress
+  }
+);
 ```
 
 ## Cancellation
 
 ```javascript
 venmoInstance.cancelTokenization(function (err) {
-  if (!err) console.log('Cancelled');
+  if (!err) console.log("Cancelled");
 });
 ```
 
@@ -149,23 +174,23 @@ venmoInstance.cancelTokenization(function (err) {
 venmoInstance.isBrowserSupported({
   allowNewBrowserTab: true,
   allowWebviews: true,
-  allowDesktop: true
+  allowDesktop: true,
 });
 // Returns boolean
 ```
 
 ## Common Errors
 
-| Code | Type | Fix |
-|------|------|-----|
-| `VENMO_NOT_ENABLED` | MERCHANT | Enable Venmo in Braintree control panel |
-| `VENMO_APP_CANCELED` | CUSTOMER | User cancelled in Venmo app, allow retry |
-| `VENMO_DESKTOP_CANCELED` | CUSTOMER | User closed QR modal, allow retry |
-| `VENMO_MOBILE_POLLING_TOKENIZATION_TIMEOUT` | CUSTOMER | User took >5 minutes, allow retry |
+| Code                                        | Type     | Fix                                         |
+| ------------------------------------------- | -------- | ------------------------------------------- |
+| `VENMO_NOT_ENABLED`                         | MERCHANT | Enable Venmo in Braintree control panel     |
+| `VENMO_APP_CANCELED`                        | CUSTOMER | User cancelled in Venmo app, allow retry    |
+| `VENMO_DESKTOP_CANCELED`                    | CUSTOMER | User closed QR modal, allow retry           |
+| `VENMO_MOBILE_POLLING_TOKENIZATION_TIMEOUT` | CUSTOMER | User took >5 minutes, allow retry           |
 | `VENMO_MOBILE_POLLING_TOKENIZATION_EXPIRED` | CUSTOMER | Payment context expired, create new payment |
-| `VENMO_TOKENIZATION_REQUEST_ACTIVE` | MERCHANT | Already tokenizing, wait for completion |
-| `VENMO_ECD_DISABLED` | MERCHANT | Enable Enriched Customer Data in settings |
-| `VENMO_INVALID_PROFILE_ID` | MERCHANT | Use valid profile ID from control panel |
+| `VENMO_TOKENIZATION_REQUEST_ACTIVE`         | MERCHANT | Already tokenizing, wait for completion     |
+| `VENMO_ECD_DISABLED`                        | MERCHANT | Enable Enriched Customer Data in settings   |
+| `VENMO_INVALID_PROFILE_ID`                  | MERCHANT | Use valid profile ID from control panel     |
 
 ## Polling Details
 

--- a/.well-known/agent-skills/skills/braintree-venmo.md
+++ b/.well-known/agent-skills/skills/braintree-venmo.md
@@ -1,0 +1,180 @@
+---
+name: braintree-venmo
+description: Venmo payments across mobile and desktop - app deep-link, QR code, web login, polling, and browser detection
+---
+
+# Venmo Integration
+
+## Platform Flows
+
+| Flow | Platform | Config | Mechanism |
+|------|----------|--------|-----------|
+| Mobile app deep-link | iOS/Android | Default | Opens Venmo app, polls for result |
+| Mobile web fallback | Mobile (no app) | `mobileWebFallBack: true` | Web login in new tab |
+| Desktop QR code | Desktop | `allowDesktop: true` | Modal with QR code, phone scan |
+| Desktop web login | Desktop | `allowDesktopWebLogin: true` | Popup window login |
+
+## Basic Setup
+
+```javascript
+braintree.venmo.create({
+  client: clientInstance,
+  allowDesktop: true,
+  paymentMethodUsage: 'single_use'  // or 'multi_use'
+}).then(function (venmoInstance) {
+
+  // Check browser support first
+  if (!venmoInstance.isBrowserSupported()) {
+    console.log('Venmo not supported');
+    return;
+  }
+
+  payButton.addEventListener('click', function () {
+    venmoInstance.tokenize(function (err, payload) {
+      if (err) {
+        if (err.code === 'VENMO_CANCELED' || err.code === 'VENMO_APP_CANCELED' ||
+            err.code === 'VENMO_CUSTOMER_CANCELED' || err.code === 'VENMO_DESKTOP_CANCELED') {
+          console.log('User cancelled');
+          return;
+        }
+        console.error(err);
+        return;
+      }
+
+      // payload.nonce, payload.details.username, payload.details.payerInfo
+      submitNonceToServer(payload.nonce);
+    });
+  });
+});
+```
+
+## Configuration Options
+
+```javascript
+braintree.venmo.create({
+  client: clientInstance,
+
+  // Mobile
+  allowNewBrowserTab: true,        // Allow new tab for auth
+  allowWebviews: true,             // Allow from webviews (Instagram, Facebook, and others)
+  mobileWebFallBack: true,         // Web login if no Venmo app
+  requireManualReturn: false,      // User must manually return to merchant
+
+  // Desktop
+  allowDesktop: true,              // Enable desktop QR code flow
+  allowDesktopWebLogin: false,     // Use popup login instead of QR
+  styleCspNonce: 'nonce-value',    // Required with CSP for injected styles
+
+  // Payment context
+  paymentMethodUsage: 'single_use', // Required for desktop flows
+  profileId: 'venmo-profile-id',
+  displayName: 'My Business',
+  riskCorrelationId: 'custom-id',  // Custom risk tracking ID
+
+  // Enriched customer data
+  collectCustomerBillingAddress: true,
+  collectCustomerShippingAddress: true,
+  totalAmount: '100.00',
+  lineItems: [{
+    quantity: 1,
+    unitAmount: '100.00',
+    name: 'Premium Widget',
+    kind: 'debit'
+  }]
+});
+```
+
+## Desktop QR Code Flow
+
+```javascript
+braintree.venmo.create({
+  client: clientInstance,
+  allowDesktop: true,
+  paymentMethodUsage: 'single_use'
+}).then(function (venmoInstance) {
+  payButton.addEventListener('click', function () {
+    venmoInstance.tokenize(function (err, payload) {
+      // Modal with QR code appears automatically
+      // SDK polls every 1 second for approval
+      // Modal closes on approval after 2-second visual delay
+      if (err) return;
+      submitNonceToServer(payload.nonce);
+    });
+  });
+});
+```
+
+## Desktop Web Login Flow
+
+```javascript
+braintree.venmo.create({
+  client: clientInstance,
+  allowDesktopWebLogin: true,
+  paymentMethodUsage: 'single_use',
+  styleCspNonce: document.querySelector('meta[name="csp-nonce"]').content
+}).then(function (venmoInstance) {
+  // Opens popup window for Venmo web login
+  // No QR code, no polling
+});
+```
+
+## Enriched Customer Data
+
+```javascript
+venmoInstance.tokenize({
+  totalAmount: '100.00',
+  collectCustomerBillingAddress: true,
+  collectCustomerShippingAddress: true,
+  isFinalAmount: true,
+  lineItems: [{
+    quantity: 1, unitAmount: '100.00', name: 'Widget', kind: 'debit'
+  }]
+}, function (err, payload) {
+  // payload.details.billingAddress
+  // payload.details.shippingAddress
+});
+```
+
+## Cancellation
+
+```javascript
+venmoInstance.cancelTokenization(function (err) {
+  if (!err) console.log('Cancelled');
+});
+```
+
+## isBrowserSupported Options
+
+```javascript
+venmoInstance.isBrowserSupported({
+  allowNewBrowserTab: true,
+  allowWebviews: true,
+  allowDesktop: true
+});
+// Returns boolean
+```
+
+## Common Errors
+
+| Code | Type | Fix |
+|------|------|-----|
+| `VENMO_NOT_ENABLED` | MERCHANT | Enable Venmo in Braintree control panel |
+| `VENMO_APP_CANCELED` | CUSTOMER | User cancelled in Venmo app, allow retry |
+| `VENMO_DESKTOP_CANCELED` | CUSTOMER | User closed QR modal, allow retry |
+| `VENMO_MOBILE_POLLING_TOKENIZATION_TIMEOUT` | CUSTOMER | User took >5 minutes, allow retry |
+| `VENMO_MOBILE_POLLING_TOKENIZATION_EXPIRED` | CUSTOMER | Payment context expired, create new payment |
+| `VENMO_TOKENIZATION_REQUEST_ACTIVE` | MERCHANT | Already tokenizing, wait for completion |
+| `VENMO_ECD_DISABLED` | MERCHANT | Enable Enriched Customer Data in settings |
+| `VENMO_INVALID_PROFILE_ID` | MERCHANT | Use valid profile ID from control panel |
+
+## Polling Details
+
+- **Mobile:** 250ms interval, 5-minute timeout, 3 max retries
+- **Desktop QR:** 1-second interval, visual delay before close
+- **Desktop web login:** No polling (popup-based)
+
+## CSP Requirements
+
+- `style-src`: Use `styleCspNonce` for dynamically injected styles
+- `img-src`: `data:` URIs for QR code canvas
+- `connect-src`: Braintree GraphQL endpoint for polling

--- a/scripts/generate-agent-skills-index.js
+++ b/scripts/generate-agent-skills-index.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var crypto = require("crypto");
+var fs = require("fs");
+var path = require("path");
+
+var SKILLS_DIR = path.join(
+  __dirname,
+  "..",
+  ".well-known",
+  "agent-skills",
+  "skills"
+);
+var INDEX_PATH = path.join(
+  __dirname,
+  "..",
+  ".well-known",
+  "agent-skills",
+  "index.json"
+);
+var SCHEMA_URL = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+
+/**
+ * Parse YAML frontmatter from a markdown file.
+ * Expects --- delimiters. Returns { name, description } or null.
+ */
+function parseFrontmatter(content) {
+  var match = content.match(/^---\n([\s\S]*?)\n---/);
+
+  if (!match) {
+    return null;
+  }
+
+  var frontmatter = match[1];
+  var result = {};
+
+  frontmatter.split("\n").forEach(function (line) {
+    var colonIndex = line.indexOf(":");
+    var key, value;
+
+    if (colonIndex > 0) {
+      key = line.slice(0, colonIndex).trim();
+      value = line.slice(colonIndex + 1).trim();
+
+      result[key] = value;
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Compute SHA-256 digest of file contents.
+ */
+function computeDigest(filePath) {
+  var content = fs.readFileSync(filePath);
+  var hash = crypto.createHash("sha256").update(content).digest("hex");
+
+  return "sha256:" + hash;
+}
+
+function main() {
+  if (!fs.existsSync(SKILLS_DIR)) {
+    console.error("Skills directory not found:", SKILLS_DIR);
+    process.exit(1);
+  }
+
+  var files = fs
+    .readdirSync(SKILLS_DIR)
+    .filter(function (f) {
+      return f.endsWith(".md");
+    })
+    .sort();
+
+  var skills = [];
+  var errors = [];
+
+  files.forEach(function (filename) {
+    var filePath = path.join(SKILLS_DIR, filename);
+    var content = fs.readFileSync(filePath, "utf8");
+    var meta = parseFrontmatter(content);
+
+    if (!meta || !meta.name || !meta.description) {
+      errors.push(
+        filename + ": missing required frontmatter (name, description)"
+      );
+
+      return;
+    }
+
+    // Validate name format: 1-64 chars, lowercase alphanumeric + hyphens
+    if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(meta.name)) {
+      errors.push(
+        filename +
+          ': invalid name "' +
+          meta.name +
+          '" (must be 1-64 lowercase alphanumeric + hyphens)'
+      );
+
+      return;
+    }
+
+    // Validate description length
+    if (meta.description.length > 1024) {
+      errors.push(
+        filename +
+          ": description exceeds 1024 characters (" +
+          meta.description.length +
+          ")"
+      );
+
+      return;
+    }
+
+    skills.push({
+      name: meta.name,
+      type: "skill-md",
+      description: meta.description,
+      url: "skills/" + filename,
+      digest: computeDigest(filePath),
+    });
+  });
+
+  if (errors.length > 0) {
+    console.error("Errors found:");
+    errors.forEach(function (e) {
+      console.error("  - " + e);
+    });
+    process.exit(1);
+  }
+
+  var index = {
+    $schema: SCHEMA_URL,
+    skills: skills,
+  };
+
+  fs.writeFileSync(INDEX_PATH, JSON.stringify(index, null, 2) + "\n");
+
+  console.log("Generated " + INDEX_PATH);
+  console.log("Skills registered: " + skills.length);
+  skills.forEach(function (s) {
+    console.log("  - " + s.name + " (" + s.digest.slice(0, 15) + "...)");
+  });
+}
+
+main();

--- a/src/client/request/jsonp-driver.js
+++ b/src/client/request/jsonp-driver.js
@@ -42,7 +42,8 @@ function _createScriptTag(url, callbackName) {
 function _cleanupGlobal(callbackName) {
   try {
     delete window[callbackName];
-  } catch (_) {
+    // eslint-disable-next-line no-unused-vars
+  } catch (e) {
     window[callbackName] = null;
   }
 }

--- a/test/data-collector/unit/kount.js
+++ b/test/data-collector/unit/kount.js
@@ -190,8 +190,8 @@ describe("kount", () => {
       });
 
       expect(actual).toEqual({
-        device_session_id: "my_device_session_id", // eslint-disable-line camelcase
-        fraud_merchant_id: "id", // eslint-disable-line camelcase
+        device_session_id: "my_device_session_id",
+        fraud_merchant_id: "id",
       });
     });
   });

--- a/test/three-d-secure/unit/external/frameworks/legacy.js
+++ b/test/three-d-secure/unit/external/frameworks/legacy.js
@@ -321,7 +321,6 @@ describe("LegacyFramework", () => {
             );
 
             authenticationCompleteHandler({
-              // eslint-disable-next-line camelcase
               auth_response:
                 '{"paymentMethod":{"type":"CreditCard","nonce":"some-fake-nonce","description":"ending+in+00","consumed":false,"threeDSecureInfo":{"liabilityShifted":true,"liabilityShiftPossible":true,"status":"authenticate_successful","enrolled":"Y"},"details":{"lastTwo":"00","cardType":"Visa"}},"threeDSecureInfo":{"liabilityShifted":true,"liabilityShiftPossible":true},"success":true}',
             });
@@ -354,7 +353,6 @@ describe("LegacyFramework", () => {
             );
 
             authenticationCompleteHandler({
-              // eslint-disable-next-line camelcase
               auth_response:
                 '{"paymentMethod":{"type":"CreditCard","nonce":"some-fake-nonce","description":"ending+in+00","consumed":false,"threeDSecureInfo":{"liabilityShifted":true,"liabilityShiftPossible":true,"status":"authenticate_successful","enrolled":"Y"},"details":{"lastTwo":"00","cardType":"Visa"}},"threeDSecureInfo":{"liabilityShifted":true,"liabilityShiftPossible":true},"success":true}',
             });
@@ -490,7 +488,6 @@ describe("LegacyFramework", () => {
           );
 
           authenticationCompleteHandler({
-            // eslint-disable-next-line camelcase
             auth_response: JSON.stringify(authResponse),
           });
         };


### PR DESCRIPTION
## Summary
- Add `.well-known/agent-skills/` directory following the [Agent Skills Discovery spec (0.2.0)](https://schemas.agentskills.io/discovery/0.2.0/schema.json) to enable AI coding assistants to discover and use Braintree Web SDK integration guides
- 12 skill files covering SDK overview, card payments, 3D Secure, PayPal, Apple Pay, Google Pay, Venmo, alternative payment methods, error resolution, migration, and advanced patterns
- Index generator script (`scripts/generate-agent-skills-index.js`) with frontmatter parsing and SHA-256 digest validation
- Minor pre-existing lint and formatting fixes required by pre-commit hooks

## Test plan
- [ ] Verify `node scripts/generate-agent-skills-index.js` regenerates `index.json` correctly
- [ ] Validate `index.json` against the 0.2.0 schema
- [ ] Confirm skill markdown files render correctly
- [ ] Run `npm run lint` passes with no errors